### PR TITLE
Implement `Clone` for component structs and `Box<dyn Component>`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ ron = "0.7.0"
 rprompt = "1.0.5"
 serde = {version = "1.0.131", features = ["derive"]}
 trait-set = "0.3.0"
+dyn-clone = "1.0.9"
+derivative = "2.2.0"
 
 [dev-dependencies]
 proptest = "1.0.0"

--- a/src/framework/conditions.rs
+++ b/src/framework/conditions.rs
@@ -1,5 +1,6 @@
 /// The Condition trait and combinators.
 use crate::{framework::components::AnyComponent, problems::Problem, state::State};
+use derivative::Derivative;
 use serde::Serialize;
 
 /// A condition for loops or branches.
@@ -14,10 +15,12 @@ pub trait Condition<P>: AnyComponent {
     fn evaluate(&self, problem: &P, state: &mut State) -> bool;
 }
 erased_serde::serialize_trait_object!(<P: Problem> Condition<P>);
+dyn_clone::clone_trait_object!(<P: Problem> Condition<P>);
 
 /// Multiple conditions must be true.
-#[derive(Serialize)]
+#[derive(Serialize, Derivative)]
 #[serde(bound = "")]
+#[derivative(Clone(bound = ""))]
 pub struct And<P: Problem>(Vec<Box<dyn Condition<P>>>);
 impl<P: Problem + 'static> And<P> {
     pub fn new(conditions: Vec<Box<dyn Condition<P>>>) -> Box<dyn Condition<P>> {
@@ -46,8 +49,9 @@ impl<P: Problem + 'static> std::ops::BitAnd for Box<dyn Condition<P>> {
 }
 
 /// Any condition must be true.
-#[derive(Serialize)]
+#[derive(Serialize, Derivative)]
 #[serde(bound = "")]
+#[derivative(Clone(bound = ""))]
 pub struct Or<P: Problem>(Vec<Box<dyn Condition<P>>>);
 impl<P: Problem + 'static> Or<P> {
     pub fn new(conditions: Vec<Box<dyn Condition<P>>>) -> Box<dyn Condition<P>> {

--- a/src/framework/configuration.rs
+++ b/src/framework/configuration.rs
@@ -9,6 +9,7 @@ use crate::{
 };
 
 /// A heuristic, constructed from a set of components.
+#[derive(Clone)]
 pub struct Configuration<P: Problem>(Box<dyn Component<P>>);
 
 impl<P: Problem> Configuration<P> {
@@ -132,12 +133,18 @@ impl<P: Problem> ConfigurationBuilder<P> {
     ///
     /// Uses the [Debug][operators::misc::Debug] component internally.
     #[track_caller]
-    pub fn assert(self, assert: impl Fn(&state::State) -> bool + Send + Sync + 'static) -> Self {
+    pub fn assert(
+        self,
+        assert: impl Fn(&state::State) -> bool + Send + Sync + Clone + 'static,
+    ) -> Self {
         self.debug(move |_problem, state| assert!(assert(state)))
     }
 
     /// Constructs a [Debug][operators::misc::Debug] component with the given behaviour.
-    pub fn debug(self, behaviour: impl Fn(&P, &mut state::State) + Send + Sync + 'static) -> Self {
+    pub fn debug(
+        self,
+        behaviour: impl Fn(&P, &mut state::State) + Send + Sync + Clone + 'static,
+    ) -> Self {
         self.do_(operators::misc::Debug::new(behaviour))
     }
 

--- a/src/heuristics/aco.rs
+++ b/src/heuristics/aco.rs
@@ -144,7 +144,7 @@ mod ant_ops {
     };
     use rand::distributions::{Distribution, WeightedIndex};
 
-    #[derive(serde::Serialize)]
+    #[derive(serde::Serialize, Clone)]
     pub struct AcoGeneration {
         pub number_of_ants: usize,
         pub alpha: f64,
@@ -228,7 +228,7 @@ mod ant_ops {
         }
     }
 
-    #[derive(serde::Serialize)]
+    #[derive(serde::Serialize, Clone)]
     pub struct AsPheromoneUpdate {
         pub evaporation: f64,
         pub decay_coefficient: f64,
@@ -267,7 +267,7 @@ mod ant_ops {
         }
     }
 
-    #[derive(serde::Serialize)]
+    #[derive(serde::Serialize, Clone)]
     pub struct MinMaxPheromoneUpdate {
         pub evaporation: f64,
         pub max_pheromones: f64,

--- a/src/heuristics/pso.rs
+++ b/src/heuristics/pso.rs
@@ -40,7 +40,7 @@ where
         .update_best_individual()
         .do_(pso(
             Parameters {
-                particle_init: state::PsoState::intializer(v_max),
+                particle_init: state::PsoState::initializer(v_max),
                 particle_update: generation::swarm::PsoGeneration::new(weight, c_one, c_two, v_max),
                 state_update: state::PsoState::updater(),
             },

--- a/src/operators/evaluation.rs
+++ b/src/operators/evaluation.rs
@@ -8,7 +8,7 @@ use crate::{
     state::{common, State},
 };
 
-#[derive(Serialize)]
+#[derive(Serialize, Clone)]
 pub struct SequentialEvaluator;
 
 impl SequentialEvaluator {
@@ -45,7 +45,7 @@ impl<P: Problem> Component<P> for SequentialEvaluator {
 }
 
 /// Inserts and updates the [common::BestIndividual] state.
-#[derive(Serialize)]
+#[derive(Serialize, Clone)]
 pub struct UpdateBestIndividual;
 
 impl UpdateBestIndividual {
@@ -77,7 +77,7 @@ impl<P: SingleObjectiveProblem> Component<P> for UpdateBestIndividual {
 }
 
 /// Inserts and updates the [common::ParetoFront] state.
-#[derive(Serialize)]
+#[derive(Serialize, Clone)]
 pub struct UpdateParetoFront;
 
 impl UpdateParetoFront {

--- a/src/operators/generation/mod.rs
+++ b/src/operators/generation/mod.rs
@@ -32,13 +32,13 @@ pub trait Generation<P: Problem> {
     );
 }
 
-#[derive(serde::Serialize)]
-pub struct Generator<T>(pub T);
+#[derive(serde::Serialize, Clone)]
+pub struct Generator<T: Clone>(pub T);
 
 impl<T, P> Component<P> for Generator<T>
 where
     P: Problem,
-    T: AnyComponent + Generation<P> + Serialize,
+    T: AnyComponent + Generation<P> + Serialize + Clone,
 {
     fn execute(&self, problem: &P, state: &mut State) {
         let population = state.population_stack_mut::<P>().pop();
@@ -73,13 +73,13 @@ pub trait Recombination<P: Problem> {
     );
 }
 
-#[derive(serde::Serialize)]
-pub struct Recombinator<T>(pub T);
+#[derive(serde::Serialize, Clone)]
+pub struct Recombinator<T: Clone>(pub T);
 
 impl<T, P, D> Component<P> for Recombinator<T>
 where
     P: Problem<Encoding = Vec<D>>,
-    T: AnyComponent + Recombination<P> + Serialize,
+    T: AnyComponent + Recombination<P> + Serialize + Clone,
     D: Clone + PartialEq + 'static,
 {
     fn execute(&self, problem: &P, state: &mut State) {

--- a/src/operators/generation/mutation.rs
+++ b/src/operators/generation/mutation.rs
@@ -17,7 +17,7 @@ use super::{Generation, Generator};
 /// Uses a `N(0, deviation)` normal distribution.
 /// Currently the same as Gaussian but without mutation rate.
 //TODO: maybe change this to generating new value (as in uniform mutation) but with Gaussian distr.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct FixedDeviationDelta {
     /// Standard Deviation for the mutation.
     pub deviation: f64,
@@ -56,7 +56,7 @@ where
 /// ```math
 /// final_deviation + (1 - progress)^modulation * (initial_deviation - final_deviation)
 /// ```
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct IWOAdaptiveDeviationDelta {
     /// Initial standard deviation for the mutation
     pub initial_deviation: f64,
@@ -133,7 +133,7 @@ mod adaptive_deviation_delta {
 /// Uses a uniform distribution.
 ///
 /// If rm = 1, all positions of solution are mutated.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct UniformMutation {
     /// Probability of mutating one position.
     pub rm: f64,
@@ -199,7 +199,7 @@ mod uniform_mutation {
 /// Uses a Gaussian distribution.
 ///
 /// If rm = 1, all positions of solution are mutated.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct GaussianMutation {
     /// Probability of mutating one position.
     pub rm: f64,
@@ -270,7 +270,7 @@ mod gaussian_mutation {
 /// Only for binary encodings!
 ///
 /// If rm = 1, all positions of solution are mutated.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct BitflipMutation {
     /// Probability of mutating one position.
     pub rm: f64,
@@ -310,7 +310,7 @@ where
 /// For more than two elements: swap is performed circular.
 ///
 /// If pm = 1, all positions of solution are mutated.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct SwapMutation {
     /// Probability of mutation.
     pub pm: f64,
@@ -388,7 +388,7 @@ mod swap_mutation {
 /// Shuffles the solution.
 ///
 /// If pm = 1, the solution is mutated.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct ScrambleMutation {
     /// Probability of mutating the solution.
     pub pm: f64,
@@ -451,7 +451,7 @@ mod scramble_mutation {
 /// Removes one random element of the solution and inserts it on a random position.
 ///
 /// If pm = 1, the solution is mutated.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct InsertionMutation {
     /// Probability of mutating the solution.
     pub pm: f64,
@@ -515,7 +515,7 @@ mod insertion_mutation {
 /// Takes a random slice of the solution and inverts it.
 ///
 /// If pm = 1, the solution is mutated.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct InversionMutation {
     /// Probability of mutating the solution.
     pub pm: f64,
@@ -582,7 +582,7 @@ mod inversion_mutation {
 /// Takes a random slice of the solution and inserts it at a new position.
 ///
 /// If pm = 1, the solution is mutated.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct TranslocationMutation {
     /// Probability of mutating the solution.
     pub pm: f64,

--- a/src/operators/generation/recombination.rs
+++ b/src/operators/generation/recombination.rs
@@ -12,7 +12,7 @@ use super::{Recombination, Recombinator};
 /// Applies a n-point crossover to two parent solutions depending on crossover probability.
 ///
 /// If pc = 1, the solutions are recombined.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct NPointCrossover {
     /// Probability of recombining the solutions.
     pub pc: f64,
@@ -106,7 +106,7 @@ mod npoint_crossover {
 /// Applies a uniform crossover to two parent solutions depending on crossover probability.
 ///
 /// If pc = 1, the solutions are recombined.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct UniformCrossover {
     /// Probability of recombining the solutions.
     pub pc: f64,
@@ -193,7 +193,7 @@ mod uniform_crossover {
 /// Usually exclusive to combinatorial problems.
 ///
 /// If pc = 1, the solutions are recombined.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct CycleCrossover {
     /// Probability of recombining the solutions.
     pub pc: f64,

--- a/src/operators/generation/swarm.rs
+++ b/src/operators/generation/swarm.rs
@@ -13,7 +13,7 @@ use crate::{
 /// Applies the PSO specific generation operator.
 ///
 /// Requires [PsoStateUpdate][crate::heuristics::pso::pso_ops::PsoStateUpdate].
-#[derive(serde::Serialize)]
+#[derive(serde::Serialize, Clone)]
 pub struct PsoGeneration {
     /// Inertia weight for influence of old velocity
     pub weight: f64,

--- a/src/operators/initialization.rs
+++ b/src/operators/initialization.rs
@@ -18,13 +18,13 @@ pub trait Initialization<P: Problem>: AnyComponent {
     fn initialize_population(&self, problem: &P, state: &mut State) -> Vec<Individual<P>>;
 }
 
-#[derive(Serialize)]
-pub struct Initializer<T>(pub T);
+#[derive(Serialize, Clone)]
+pub struct Initializer<T: Clone>(pub T);
 
 impl<T, P> Component<P> for Initializer<T>
 where
     P: Problem,
-    T: AnyComponent + Initialization<P> + Serialize,
+    T: AnyComponent + Initialization<P> + Serialize + Clone,
 {
     fn execute(&self, problem: &P, state: &mut State) {
         let population = self.0.initialize_population(problem, state);
@@ -33,7 +33,7 @@ where
 }
 
 /// Initializes an empty population.
-#[derive(Serialize)]
+#[derive(Serialize, Clone)]
 pub struct Empty;
 impl Empty {
     pub fn new<P>() -> Box<dyn Component<P>>
@@ -50,7 +50,7 @@ impl<P: Problem> Initialization<P> for Empty {
 }
 
 /// Generates new random solutions in the search space.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct RandomSpread {
     /// Size of the initial population.
     pub initial_population_size: Option<u32>,
@@ -104,7 +104,7 @@ where
 }
 
 /// Generates new random permutations for combinatorial problems.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct RandomPermutation {
     /// Size of the initial population.
     pub initial_population_size: Option<u32>,
@@ -151,11 +151,11 @@ where
 }
 
 /// Generates new random binary string for binary problems.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct RandomBitstring {
     /// Size of the initial population.
     pub initial_population_size: Option<u32>,
-    // Probability of generating a 1 / true.
+    // Probability of generating a 1 or true.
     pub p: f64,
 }
 impl RandomBitstring {

--- a/src/operators/replacement.rs
+++ b/src/operators/replacement.rs
@@ -24,13 +24,13 @@ pub trait Replacement<P: Problem> {
     );
 }
 
-#[derive(serde::Serialize)]
-pub struct Replacer<T>(pub T);
+#[derive(serde::Serialize, Clone)]
+pub struct Replacer<T: Clone>(pub T);
 
 impl<T, P> Component<P> for Replacer<T>
 where
     P: Problem,
-    T: AnyComponent + Replacement<P> + Serialize,
+    T: AnyComponent + Replacement<P> + Serialize + Clone,
 {
     fn execute(&self, _problem: &P, state: &mut State) {
         let mut offspring = state.population_stack_mut().pop();
@@ -42,7 +42,7 @@ where
 }
 
 /// Discards all individuals in the child population, keeping the parents unchanged.
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct Noop;
 impl Noop {
     pub fn new<P: Problem>() -> Box<dyn Component<P>> {
@@ -60,7 +60,7 @@ impl<P: Problem> Replacement<P> for Noop {
 }
 
 /// Always keeps the fittest individuals.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct MuPlusLambda {
     /// Limits the population growth.
     pub max_population_size: u32,
@@ -108,7 +108,7 @@ mod mupluslambda {
 }
 
 /// Always keeps the children.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct Generational {
     /// Limits the population growth.
     pub max_population_size: u32,

--- a/src/operators/selection.rs
+++ b/src/operators/selection.rs
@@ -26,13 +26,13 @@ pub trait Selection<P: Problem> {
     ) -> Vec<&'p Individual<P>>;
 }
 
-#[derive(serde::Serialize)]
-pub struct Selector<T>(pub T);
+#[derive(serde::Serialize, Clone)]
+pub struct Selector<T: Clone>(pub T);
 
 impl<T, P> Component<P> for Selector<T>
 where
     P: Problem,
-    T: AnyComponent + Selection<P> + Serialize,
+    T: AnyComponent + Selection<P> + Serialize + Clone,
 {
     fn execute(&self, _problem: &P, state: &mut State) {
         let population = state.population_stack_mut().pop();
@@ -103,7 +103,7 @@ fn get_ranking<P: SingleObjectiveProblem>(population: &[Individual<P>]) -> Vec<u
 }
 
 /// Selects all individuals once.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct All;
 impl All {
     pub fn new<P: Problem>() -> Box<dyn Component<P>> {
@@ -121,7 +121,7 @@ impl<P: Problem> Selection<P> for All {
 }
 
 /// Selects no individual.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct None;
 impl None {
     pub fn new<P: Problem>() -> Box<dyn Component<P>> {
@@ -139,7 +139,7 @@ impl<P: Problem> Selection<P> for None {
 }
 
 /// Select the single solution `offspring` times.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct DuplicateSingle {
     /// Offspring per iteration.
     pub offspring: u32,
@@ -184,7 +184,7 @@ mod duplicate_single {
 /// Selects `offspring` random solutions.
 ///
 /// Solutions can be selected multiple times in a single iteration.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct FullyRandom {
     /// Offspring per iteration.
     pub offspring: u32,
@@ -246,7 +246,7 @@ mod fully_random {
 ///
 /// # References
 /// See [crate::heuristics::iwo]
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct DeterministicFitnessProportional {
     /// Minimum offspring per individual per iteration
     pub min_offspring: u32,
@@ -335,7 +335,7 @@ mod deterministic_fitness_proportional {
 /// Selects `offspring` solutions using roulette-wheel method.
 ///
 /// Solutions can be selected multiple times in a single iteration.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct RouletteWheel {
     /// Offspring per iteration.
     pub offspring: u32,
@@ -383,7 +383,7 @@ mod roulette_wheel {
 ///
 /// Solutions can be selected multiple times in a single iteration. Population is not sorted by fitness,
 /// but individuals are weighted "in place".
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct StochasticUniversalSampling {
     /// Offspring per iteration.
     pub offspring: u32,
@@ -445,7 +445,7 @@ mod stochastic_universal_sampling {
 /// Selects `offspring` using deterministic Tournament selection.
 ///
 /// Solutions can be selected multiple times in a single iteration.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct Tournament {
     /// Offspring per iteration.
     pub offspring: u32,
@@ -509,7 +509,7 @@ mod tournament {
 /// Selects `offspring` solutions using linear ranking.
 ///
 /// Solutions can be selected multiple times in a single iteration.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct LinearRank {
     /// Offspring per iteration.
     pub offspring: u32,
@@ -559,7 +559,7 @@ mod linear_rank {
 /// Solutions can be selected multiple times in a single iteration.
 ///
 /// See [https://tik-old.ee.ethz.ch/file/6c0e384dceb283cd4301339a895b72b8/TIK-Report11.pdf](https://tik-old.ee.ethz.ch/file/6c0e384dceb283cd4301339a895b72b8/TIK-Report11.pdf) for details.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct ExponentialRank {
     /// Offspring per iteration.
     pub offspring: u32,

--- a/src/operators/termination.rs
+++ b/src/operators/termination.rs
@@ -10,32 +10,7 @@ use crate::{
 };
 use serde::{Deserialize, Serialize};
 
-/// Only a placeholder. Replace this with something else.
-///
-/// See [operators::termination][crate::operators::termination] for possible criteria.
-#[derive(Serialize, Deserialize)]
-pub struct Undefined;
-impl Undefined {
-    pub fn new<P>() -> Box<dyn Condition<P>>
-    where
-        P: Problem,
-    {
-        Box::new(Self)
-    }
-}
-impl<P> Condition<P> for Undefined
-where
-    P: Problem,
-{
-    fn evaluate(&self, _problem: &P, _state: &mut State) -> bool {
-        unimplemented!(concat!(
-            "Heuristic with no termination criteria was run. ",
-            "Please specify a termination criteria."
-        ));
-    }
-}
-
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct TargetHit;
 impl TargetHit {
     pub fn new<P>() -> Box<dyn Condition<P>>
@@ -61,7 +36,7 @@ where
 /// Terminates after a fixed number of iterations.
 ///
 /// Supports measuring time to completion.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct FixedIterations {
     /// Maximum number of iterations.
     pub max_iterations: u32,
@@ -131,7 +106,7 @@ mod fixed_iterations {
 /// Terminates after a fixed number of evaluations.
 ///
 /// Supports measuring time to completion.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct FixedEvaluations {
     /// Maximum number of evaluations.
     pub max_evaluations: u32,
@@ -201,7 +176,7 @@ mod fixed_evaluations {
 /// Is restricted to problems where the optimum is known, i.e., implement [HasKnownOptimum].
 ///
 /// Progress is unknown, as optimizer should not have information on optimum.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct DistanceToOpt {
     /// Distance to known optimum.
     pub distance: f64,
@@ -267,7 +242,7 @@ impl CustomState for FitnessImprovementState {}
 /// Terminates after a specified number of steps (iterations) did not yield any improvement.
 ///
 /// Progress is unknown, as steps depend on current performance of optimizer.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct StepsWithoutImprovement {
     /// Number of steps without improvement.
     pub steps: usize,

--- a/src/state/archive.rs
+++ b/src/state/archive.rs
@@ -44,7 +44,7 @@ impl<P: SingleObjectiveProblem> ElitistArchive<P> {
 impl<P: SingleObjectiveProblem> ElitistArchive<P> {
     /// Updates the [ElitistArchiveState] with the current population.
     pub fn update(n_elitists: usize) -> Box<dyn Component<P>> {
-        #[derive(Serialize, Deserialize)]
+        #[derive(Serialize, Deserialize, Clone)]
         pub struct ElitistArchiveUpdate {
             pub n_elitists: usize,
         }
@@ -71,7 +71,7 @@ impl<P: SingleObjectiveProblem> ElitistArchive<P> {
 
     /// Adds elitists from [ElitistArchiveState] to the population.
     pub fn add_elitists() -> Box<dyn Component<P>> {
-        #[derive(Serialize, Deserialize)]
+        #[derive(Serialize, Deserialize, Clone)]
         pub struct AddElitists;
 
         impl<P> Component<P> for AddElitists

--- a/src/state/diversity.rs
+++ b/src/state/diversity.rs
@@ -33,7 +33,7 @@ impl DiversityState {
     where
         P: Problem<Encoding = Vec<f64>> + VectorProblem<T = f64>,
     {
-        #[derive(Debug, serde::Serialize)]
+        #[derive(Debug, serde::Serialize, Clone)]
         pub struct FloatVectorDiversity {
             pub measure: DiversityMeasure,
         }

--- a/src/state/pso.rs
+++ b/src/state/pso.rs
@@ -23,8 +23,8 @@ where
     /// State initialization for PSO.
     ///
     /// Initializes velocities, best found solutions of particles and global best in [PsoState].
-    pub fn intializer(v_max: f64) -> Box<dyn Component<P>> {
-        #[derive(Debug, serde::Serialize)]
+    pub fn initializer(v_max: f64) -> Box<dyn Component<P>> {
+        #[derive(Debug, serde::Serialize, Clone)]
         pub struct PsoStateInitialization {
             v_max: f64,
         }
@@ -81,7 +81,7 @@ where
     ///
     /// Updates best found solutions of particles and global best in [PsoState].
     pub fn updater() -> Box<dyn Component<P>> {
-        #[derive(Debug, serde::Serialize)]
+        #[derive(Debug, serde::Serialize, Clone)]
         pub struct PsoStateUpdate;
 
         impl<P> Component<P> for PsoStateUpdate

--- a/src/tracking/logger.rs
+++ b/src/tracking/logger.rs
@@ -1,12 +1,13 @@
 use std::ops::{Deref, Sub};
 
+use serde::Serialize;
+
 use crate::{
     framework::components::Component,
     problems::{Problem, SingleObjectiveProblem},
     state::{CustomState, State},
     tracking::{self, log::Step, set::LogSet, trigger, Log},
 };
-use serde::Serialize;
 
 /// A collection of [LogSet]s.
 ///
@@ -14,11 +15,21 @@ use serde::Serialize;
 ///
 /// Implements [Component] and should be added to the end
 /// of an algorithms main loop.
+///
+/// # Cloning
+///
+/// Note that [Clone]ing does **NOT** preserve existing [LogSet]'s.
 #[derive(Serialize)]
 #[serde(bound = "")]
 pub struct Logger<P: Problem> {
     #[serde(skip)]
     sets: Vec<LogSet<P>>,
+}
+
+impl<P: Problem> Clone for Logger<P> {
+    fn clone(&self) -> Self {
+        Self::builder()
+    }
 }
 
 impl<P: Problem> Logger<P> {


### PR DESCRIPTION
Closes #118 

I used [`dyn-clone`](https://crates.io/crates/dyn-clone) to fix the problem with object-safety, and [`derivative`](https://crates.io/crates/derivative) to implement `Clone` for the specific component structs without having to modify `Problem`, as simply deriving `Clone` for some reason requires `P: Clone`.