### PR TITLE
Make framework::run a method of Configuration

### DIFF
--- a/examples/bmf.rs
+++ b/examples/bmf.rs
@@ -1,3 +1,4 @@
+use mahf::framework::Random;
 use mahf::prelude::*;
 
 type P = problems::bmf::BenchmarkFunction;
@@ -16,7 +17,7 @@ fn main() -> anyhow::Result<()> {
         tracking::Logger::default(),
     );
 
-    let state = config.run(&problem, None);
+    let state = config.optimize_with(&problem, |state| state.insert(Random::seeded(0)));
 
     println!(
         "Found Fitness: {:?}",

--- a/examples/bmf.rs
+++ b/examples/bmf.rs
@@ -3,7 +3,7 @@ use mahf::prelude::*;
 type P = problems::bmf::BenchmarkFunction;
 
 fn main() -> anyhow::Result<()> {
-    let problem = P::sphere(30);
+    let problem = P::sphere(10);
     let config = pso::real_pso(
         pso::RealProblemParameters {
             num_particles: 100,
@@ -16,7 +16,7 @@ fn main() -> anyhow::Result<()> {
         tracking::Logger::default(),
     );
 
-    let state = framework::run(&problem, &config, None);
+    let state = config.run(&problem, None);
 
     println!(
         "Found Fitness: {:?}",

--- a/examples/tsp.rs
+++ b/examples/tsp.rs
@@ -22,7 +22,7 @@ fn main() -> anyhow::Result<()> {
     .single_objective_summary()
     .build();
 
-    config.run(&problem, None);
+    config.optimize(&problem);
 
     Ok(())
 }

--- a/examples/tsp.rs
+++ b/examples/tsp.rs
@@ -22,7 +22,7 @@ fn main() -> anyhow::Result<()> {
     .single_objective_summary()
     .build();
 
-    framework::run(&problem, &config, None);
+    config.run(&problem, None);
 
     Ok(())
 }

--- a/src/framework/configuration.rs
+++ b/src/framework/configuration.rs
@@ -2,10 +2,11 @@ use crate::{
     framework::{
         components::{Block, Branch, Component, Loop, Scope},
         conditions::Condition,
+        Random,
     },
     operators,
     problems::{MultiObjectiveProblem, Problem, SingleObjectiveProblem},
-    state,
+    state, tracking,
 };
 
 /// A heuristic, constructed from a set of components.
@@ -35,6 +36,28 @@ impl<P: Problem> Configuration<P> {
 
     pub fn into_builder(self) -> ConfigurationBuilder<P> {
         ConfigurationBuilder::new().do_(self.0)
+    }
+
+    /// Runs the heuristic on the given problem.
+    ///
+    /// Returns the final state of the heuristic.
+    /// If the heuristic has a logger, that log can be obtained from
+    /// this state as well.
+    ///
+    /// If no random generator is provided, it will default
+    /// to a randomly seeded RNG.
+    pub fn run(&self, problem: &P, rng: Option<Random>) -> state::State {
+        let heuristic = self.heuristic();
+        let mut state = state::State::new_root();
+
+        state.insert(tracking::Log::new());
+        state.insert(rng.unwrap_or_default());
+        state.insert(state::common::Population::<P>::new());
+
+        heuristic.initialize(problem, &mut state);
+        heuristic.execute(problem, &mut state);
+
+        state
     }
 }
 

--- a/src/framework/configuration.rs
+++ b/src/framework/configuration.rs
@@ -46,13 +46,32 @@ impl<P: Problem> Configuration<P> {
     ///
     /// If no random generator is provided, it will default
     /// to a randomly seeded RNG.
-    pub fn run(&self, problem: &P, rng: Option<Random>) -> state::State {
+    pub fn optimize(&self, problem: &P) -> state::State {
         let heuristic = self.heuristic();
         let mut state = state::State::new_root();
 
         state.insert(tracking::Log::new());
-        state.insert(rng.unwrap_or_default());
+        state.insert(Random::default());
         state.insert(state::common::Population::<P>::new());
+
+        heuristic.initialize(problem, &mut state);
+        heuristic.execute(problem, &mut state);
+
+        state
+    }
+
+    pub fn optimize_with(
+        &self,
+        problem: &P,
+        init_state: impl FnOnce(&mut state::State),
+    ) -> state::State {
+        let heuristic = self.heuristic();
+        let mut state = state::State::new_root();
+
+        state.insert(tracking::Log::new());
+        state.insert(state::common::Population::<P>::new());
+
+        init_state(&mut state);
 
         heuristic.initialize(problem, &mut state);
         heuristic.execute(problem, &mut state);

--- a/src/framework/configuration.rs
+++ b/src/framework/configuration.rs
@@ -38,14 +38,14 @@ impl<P: Problem> Configuration<P> {
         ConfigurationBuilder::new().do_(self.0)
     }
 
-    /// Runs the heuristic on the given problem.
+    /// Runs the heuristic on the given problem, returning the final state of the heuristic.
     ///
-    /// Returns the final state of the heuristic.
-    /// If the heuristic has a logger, that log can be obtained from
-    /// this state as well.
+    /// The state is pre-initialized with a [Population][state::common::Population]
+    /// and a [Log][tracking::Log].
+    /// The random generator defaults to a randomly seeded RNG ([Random::default]).
     ///
-    /// If no random generator is provided, it will default
-    /// to a randomly seeded RNG.
+    /// For initializing the state with custom state,
+    /// see [optimize_with][Configuration::optimize_with].
     pub fn optimize(&self, problem: &P) -> state::State {
         let heuristic = self.heuristic();
         let mut state = state::State::new_root();
@@ -60,6 +60,13 @@ impl<P: Problem> Configuration<P> {
         state
     }
 
+    /// Runs the heuristic on the given problem, initializing the state with a custom function,
+    /// and returning the final state of the heuristic.
+    ///
+    /// The state is pre-initialized with a [Population][state::common::Population]
+    /// and a [Log][tracking::Log].
+    /// If no random generator is inserted in `init_state`, it will default
+    /// to a randomly seeded RNG ([Random::default]).
     pub fn optimize_with(
         &self,
         problem: &P,
@@ -72,6 +79,10 @@ impl<P: Problem> Configuration<P> {
         state.insert(state::common::Population::<P>::new());
 
         init_state(&mut state);
+
+        if !state.has::<Random>() {
+            state.insert(Random::default());
+        }
 
         heuristic.initialize(problem, &mut state);
         heuristic.execute(problem, &mut state);

--- a/src/framework/mod.rs
+++ b/src/framework/mod.rs
@@ -14,33 +14,3 @@ pub use individual::Individual;
 
 mod random;
 pub use random::{Random, RandomConfig};
-
-use crate::problems::Problem;
-use crate::state;
-use crate::tracking::Log;
-
-/// Runs the heuristic on the given problem.
-///
-/// Returns the final state of the heuristic.
-/// If the heuristic has a logger, that log can be obtained from
-/// this state as well.
-///
-/// If no random generator is provided, it will default
-/// to a randomly seeded RNG.
-pub fn run<P: Problem>(
-    problem: &P,
-    config: &Configuration<P>,
-    rng: Option<Random>,
-) -> state::State {
-    let heuristic = config.heuristic();
-    let mut state = state::State::new_root();
-
-    state.insert(Log::new());
-    state.insert(rng.unwrap_or_default());
-    state.insert(state::common::Population::<P>::new());
-
-    heuristic.initialize(problem, &mut state);
-    heuristic.execute(problem, &mut state);
-
-    state
-}

--- a/src/problems/coco_bound/suits.rs
+++ b/src/problems/coco_bound/suits.rs
@@ -1,5 +1,5 @@
 use crate::{
-    framework::{self, Configuration, Random},
+    framework::{Configuration, Random},
     problems::{coco_bound::CocoInstance, HasKnownTarget},
     tracking::{files, Log},
     utils::threads::SyncThreadPool,
@@ -62,7 +62,7 @@ pub fn evaluate_suite(
                     let experiment_desc = problem.format_name();
                     let log_file = data_dir.join(format!("{}.log", experiment_desc));
 
-                    let state = framework::run(&problem, &configuration, Some(Random::default()));
+                    let state = configuration.run(&problem, Some(Random::default()));
                     let log = state.get::<Log>();
                     files::write_log_file(log_file, log)?;
 

--- a/src/problems/coco_bound/suits.rs
+++ b/src/problems/coco_bound/suits.rs
@@ -1,5 +1,5 @@
 use crate::{
-    framework::{Configuration, Random},
+    framework::{Configuration},
     problems::{coco_bound::CocoInstance, HasKnownTarget},
     tracking::{files, Log},
     utils::threads::SyncThreadPool,
@@ -62,7 +62,7 @@ pub fn evaluate_suite(
                     let experiment_desc = problem.format_name();
                     let log_file = data_dir.join(format!("{}.log", experiment_desc));
 
-                    let state = configuration.run(&problem, Some(Random::default()));
+                    let state = configuration.optimize(&problem);
                     let log = state.get::<Log>();
                     files::write_log_file(log_file, log)?;
 

--- a/src/problems/coco_bound/suits.rs
+++ b/src/problems/coco_bound/suits.rs
@@ -1,5 +1,5 @@
 use crate::{
-    framework::{Configuration},
+    framework::Configuration,
     problems::{coco_bound::CocoInstance, HasKnownTarget},
     tracking::{files, Log},
     utils::threads::SyncThreadPool,

--- a/src/state/container/mod.rs
+++ b/src/state/container/mod.rs
@@ -138,7 +138,7 @@ impl State {
     /// Basic usage:
     ///
     /// ```
-    /// use mahf::{framework::{state::{State, common::Population}, Random}, problems::bmf::BenchmarkFunction};
+    /// use mahf::{state::{State, common::Population}, framework::Random, problems::bmf::BenchmarkFunction};
     /// let problem = BenchmarkFunction::sphere(3);
     /// let mut state = State::new_root();
     /// state.insert(Random::testing());
@@ -203,7 +203,7 @@ impl State {
     ///  Basic usage:
     ///
     /// ```
-    /// use mahf::{framework::{state::{State, common::Population}, Random}, problems::bmf::BenchmarkFunction};
+    /// use mahf::{state::{State, common::Population}, framework::Random, problems::bmf::BenchmarkFunction};
     /// let problem = BenchmarkFunction::sphere(3);
     /// let mut state = State::new_root();
     /// state.insert(Random::testing());


### PR DESCRIPTION
Just a small technicality, but `Configuration` always struck me as somewhat useless after the rework. Making `run` a method of `Configuration` gives it a real purpose, and just flows better, in my opinion.

Maybe we could also rename `run` to `solve`, `optimize`, or `search`, as a `Configuration` doesn't really “run” a problem/ solution space.