### PR TITLE
Implement Boundary Constraint Handling 

### DIFF
--- a/src/components/constraints.rs
+++ b/src/components/constraints.rs
@@ -1,24 +1,53 @@
+use rand::prelude::*;
+use serde::Serialize;
+
 use crate::{
-    framework::components::AnyComponent,
+    framework::components::{AnyComponent, Component},
     problems::{LimitedVectorProblem, Problem, VectorProblem},
+    state::State,
 };
 
-pub trait BoundaryConstraint<P: Problem>: AnyComponent {
-    fn constrain(&self, problem: &P, solution: &mut P::Encoding);
+/// Specialized component trait to constrain solutions to a domain.
+///
+/// # Implementing [Component]
+///
+/// Types implementing this trait can implement [Component] by wrapping the type in a [BoundaryConstrainer].
+pub trait BoundaryConstraint<P: Problem> {
+    fn constrain(&self, solution: &mut P::Encoding, problem: &P, state: &mut State);
 }
 
+#[derive(serde::Serialize, Clone)]
+pub struct BoundaryConstrainer<T: Clone>(pub T);
+
+impl<T, P> Component<P> for BoundaryConstrainer<T>
+where
+    P: Problem,
+    T: AnyComponent + BoundaryConstraint<P> + Serialize + Clone,
+{
+    fn execute(&self, problem: &P, state: &mut State) {
+        let mut population = state.population_stack_mut::<P>().pop();
+
+        for individual in population.iter_mut() {
+            self.0.constrain(individual.solution_mut(), problem, state);
+        }
+
+        state.population_stack_mut().push(population);
+    }
+}
+
+/// Clamps the values to the domain boundaries.
 #[derive(serde::Serialize, Clone)]
 pub struct Saturation;
 impl Saturation {
     pub fn new<P: Problem<Encoding = Vec<f64>> + VectorProblem<T = f64> + LimitedVectorProblem>(
-    ) -> Box<dyn BoundaryConstraint<P>> {
-        Box::new(Self)
+    ) -> Box<dyn Component<P>> {
+        Box::new(BoundaryConstrainer(Self))
     }
 }
 impl<P: Problem<Encoding = Vec<f64>> + VectorProblem<T = f64> + LimitedVectorProblem>
     BoundaryConstraint<P> for Saturation
 {
-    fn constrain(&self, problem: &P, solution: &mut P::Encoding) {
+    fn constrain(&self, solution: &mut Vec<f64>, problem: &P, _state: &mut State) {
         for (d, x) in solution.iter_mut().enumerate() {
             let range = problem.range(d);
             *x = x.clamp(range.start, range.end);
@@ -26,51 +55,103 @@ impl<P: Problem<Encoding = Vec<f64>> + VectorProblem<T = f64> + LimitedVectorPro
     }
 }
 
+/// Reflects values outside the domain off the opposite domain boundary inwards,
+/// as if the boundaries are connected and the domain forms a ring.
 #[derive(serde::Serialize, Clone)]
 pub struct Toroidal;
 impl Toroidal {
     pub fn new<P: Problem<Encoding = Vec<f64>> + VectorProblem<T = f64> + LimitedVectorProblem>(
-    ) -> Box<dyn BoundaryConstraint<P>> {
-        Box::new(Self)
+    ) -> Box<dyn Component<P>> {
+        Box::new(BoundaryConstrainer(Self))
     }
 }
 impl<P: Problem<Encoding = Vec<f64>> + VectorProblem<T = f64> + LimitedVectorProblem>
     BoundaryConstraint<P> for Toroidal
 {
-    fn constrain(&self, problem: &P, solution: &mut P::Encoding) {
+    fn constrain(&self, solution: &mut Vec<f64>, problem: &P, _state: &mut State) {
         for (d, x) in solution.iter_mut().enumerate() {
             let range = problem.range(d);
-            let delta = range.end - range.start;
+            let a = range.start;
+            let b = range.end;
+            let d = b - a;
+            let norm = (*x - a) / d;
+
             *x = match *x {
-                // Note that, e.g., with a bound of [-5, 5], 15 is mirrored to -5, and not 5, because of the mod operation.
-                v if v > range.end => range.start + (v - range.end) % delta,
-                v if v < range.start => range.end + (v + range.start) % delta,
+                v if v < range.start => a + (1. - (norm - norm.floor()).abs()) * d,
+                v if v > range.end => a + (norm - norm.floor()) * d,
                 v => v,
             };
         }
     }
 }
 
+/// The amount exceeding the boundary is reflected inwards at the same boundary.
 #[derive(serde::Serialize, Clone)]
 pub struct Mirror;
 impl Mirror {
     pub fn new<P: Problem<Encoding = Vec<f64>> + VectorProblem<T = f64> + LimitedVectorProblem>(
-    ) -> Box<dyn BoundaryConstraint<P>> {
-        Box::new(Self)
+    ) -> Box<dyn Component<P>> {
+        Box::new(BoundaryConstrainer(Self))
     }
 }
 impl<P: Problem<Encoding = Vec<f64>> + VectorProblem<T = f64> + LimitedVectorProblem>
     BoundaryConstraint<P> for Mirror
 {
-    fn constrain(&self, problem: &P, solution: &mut P::Encoding) {
+    fn constrain(&self, solution: &mut Vec<f64>, problem: &P, _state: &mut State) {
         for (d, x) in solution.iter_mut().enumerate() {
             let range = problem.range(d);
-            let delta = range.end - range.start;
-            *x = match *x {
-                v if v > range.end => range.end - (v - range.end) % delta,
-                v if v < range.start => range.start - (v + range.start) % delta,
-                v => v,
-            };
+            let a = range.start;
+            let b = range.end;
+
+            let mut new_x = *x;
+            while !range.contains(&new_x) {
+                new_x = match new_x {
+                    v if v < a => a + (a - v),
+                    v if v > b => b - (v - b),
+                    v => v,
+                };
+            }
+
+            *x = new_x;
+        }
+    }
+}
+
+/// The values outside the bounds \[a, b\] are re-sampled from
+/// - `a + |N(0, (b - a)/3)|` for the lower bound,
+/// - `b - |N(0, (b - a)/3)|` for the upper bound.
+///
+/// Re-sampling is performed until the value is within the domain.
+#[derive(serde::Serialize, Clone)]
+pub struct CompleteOneTailedNormalCorrection;
+impl CompleteOneTailedNormalCorrection {
+    pub fn new<P: Problem<Encoding = Vec<f64>> + VectorProblem<T = f64> + LimitedVectorProblem>(
+    ) -> Box<dyn Component<P>> {
+        Box::new(BoundaryConstrainer(Self))
+    }
+}
+impl<P: Problem<Encoding = Vec<f64>> + VectorProblem<T = f64> + LimitedVectorProblem>
+    BoundaryConstraint<P> for CompleteOneTailedNormalCorrection
+{
+    fn constrain(&self, solution: &mut Vec<f64>, problem: &P, state: &mut State) {
+        for (d, x) in solution.iter_mut().enumerate() {
+            let range = problem.range(d);
+            let a = range.start;
+            let b = range.end;
+
+            let rng = state.random_mut();
+            let dist = rand_distr::Normal::new(0., (b - a) / 3.).unwrap();
+
+            let mut new_x = *x;
+            while !range.contains(&new_x) {
+                new_x = match new_x {
+                    v if v < a => a + dist.sample(rng).abs(),
+                    v if v > b => b - dist.sample(rng).abs(),
+                    v => v,
+                }
+            }
+
+            *x = new_x;
         }
     }
 }

--- a/src/components/constraints.rs
+++ b/src/components/constraints.rs
@@ -1,0 +1,76 @@
+use crate::{
+    framework::components::AnyComponent,
+    problems::{LimitedVectorProblem, Problem, VectorProblem},
+};
+
+pub trait BoundaryConstraint<P: Problem>: AnyComponent {
+    fn constrain(&self, problem: &P, solution: &mut P::Encoding);
+}
+
+#[derive(serde::Serialize, Clone)]
+pub struct Saturation;
+impl Saturation {
+    pub fn new<P: Problem<Encoding = Vec<f64>> + VectorProblem<T = f64> + LimitedVectorProblem>(
+    ) -> Box<dyn BoundaryConstraint<P>> {
+        Box::new(Self)
+    }
+}
+impl<P: Problem<Encoding = Vec<f64>> + VectorProblem<T = f64> + LimitedVectorProblem>
+    BoundaryConstraint<P> for Saturation
+{
+    fn constrain(&self, problem: &P, solution: &mut P::Encoding) {
+        for (d, x) in solution.iter_mut().enumerate() {
+            let range = problem.range(d);
+            *x = x.clamp(range.start, range.end);
+        }
+    }
+}
+
+#[derive(serde::Serialize, Clone)]
+pub struct Toroidal;
+impl Toroidal {
+    pub fn new<P: Problem<Encoding = Vec<f64>> + VectorProblem<T = f64> + LimitedVectorProblem>(
+    ) -> Box<dyn BoundaryConstraint<P>> {
+        Box::new(Self)
+    }
+}
+impl<P: Problem<Encoding = Vec<f64>> + VectorProblem<T = f64> + LimitedVectorProblem>
+    BoundaryConstraint<P> for Toroidal
+{
+    fn constrain(&self, problem: &P, solution: &mut P::Encoding) {
+        for (d, x) in solution.iter_mut().enumerate() {
+            let range = problem.range(d);
+            let delta = range.end - range.start;
+            *x = match *x {
+                // Note that, e.g., with a bound of [-5, 5], 15 is mirrored to -5, and not 5, because of the mod operation.
+                v if v > range.end => range.start + (v - range.end) % delta,
+                v if v < range.start => range.end + (v + range.start) % delta,
+                v => v,
+            };
+        }
+    }
+}
+
+#[derive(serde::Serialize, Clone)]
+pub struct Mirror;
+impl Mirror {
+    pub fn new<P: Problem<Encoding = Vec<f64>> + VectorProblem<T = f64> + LimitedVectorProblem>(
+    ) -> Box<dyn BoundaryConstraint<P>> {
+        Box::new(Self)
+    }
+}
+impl<P: Problem<Encoding = Vec<f64>> + VectorProblem<T = f64> + LimitedVectorProblem>
+    BoundaryConstraint<P> for Mirror
+{
+    fn constrain(&self, problem: &P, solution: &mut P::Encoding) {
+        for (d, x) in solution.iter_mut().enumerate() {
+            let range = problem.range(d);
+            let delta = range.end - range.start;
+            *x = match *x {
+                v if v > range.end => range.end - (v - range.end) % delta,
+                v if v < range.start => range.start - (v + range.start) % delta,
+                v => v,
+            };
+        }
+    }
+}

--- a/src/components/generation/swarm.rs
+++ b/src/components/generation/swarm.rs
@@ -84,8 +84,7 @@ where
             }
 
             for i in 0..x.len() {
-                //TODO we will need constraint handling here
-                x[i] = (x[i] + v[i]).clamp(-1.0, 1.0);
+                x[i] += v[i];
             }
 
             offspring.push(Individual::<P>::new_unevaluated(x));

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -4,10 +4,10 @@
 
 #![allow(clippy::new_ret_no_self)]
 
+pub mod constraints;
 pub mod evaluation;
 pub mod generation;
 pub mod initialization;
 pub mod misc;
 pub mod replacement;
 pub mod selection;
-pub mod constraints;

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -10,3 +10,4 @@ pub mod initialization;
 pub mod misc;
 pub mod replacement;
 pub mod selection;
+pub mod constraints;

--- a/src/heuristics/cro.rs
+++ b/src/heuristics/cro.rs
@@ -73,6 +73,7 @@ where
                 intermolecular_ineffective_collision: generation::mutation::UniformMutation::new(
                     1.,
                 ),
+                constraints: constraints::Saturation::new(),
             },
             termination,
             logger,
@@ -94,6 +95,7 @@ pub struct Parameters<P> {
     pub synthesis_criterion: Box<dyn Condition<P>>,
     pub synthesis: Box<dyn Component<P>>,
     pub intermolecular_ineffective_collision: Box<dyn Component<P>>,
+    pub constraints: Box<dyn Component<P>>,
 }
 
 /// A generic single-objective Chemical Reaction Optimization template.
@@ -118,6 +120,7 @@ pub fn cro<P: SingleObjectiveProblem>(
         synthesis_criterion,
         synthesis,
         intermolecular_ineffective_collision,
+        constraints,
     } = params;
 
     Configuration::builder()
@@ -133,6 +136,7 @@ pub fn cro<P: SingleObjectiveProblem>(
                                             |builder| {
                                                 builder
                                                     .do_(decomposition)
+                                                    .do_(constraints.clone())
                                                     .evaluate_sequential()
                                                     .update_best_individual()
                                                     .do_(state::CroState::decomposition_update())
@@ -140,6 +144,7 @@ pub fn cro<P: SingleObjectiveProblem>(
                                             |builder| {
                                                 builder
                                                     .do_(on_wall_ineffective_collision)
+                                                    .do_(constraints.clone())
                                                     .evaluate_sequential()
                                                     .update_best_individual()
                                                     .do_(state::CroState::on_wall_ineffective_collision_update(
@@ -156,6 +161,7 @@ pub fn cro<P: SingleObjectiveProblem>(
                                             |builder| {
                                                 builder
                                                     .do_(synthesis)
+                                                    .do_(constraints.clone())
                                                     .evaluate_sequential()
                                                     .update_best_individual()
                                                     .do_(state::CroState::synthesis_update())
@@ -163,6 +169,7 @@ pub fn cro<P: SingleObjectiveProblem>(
                                             |builder| {
                                                 builder
                                                     .do_(intermolecular_ineffective_collision)
+                                                    .do_(constraints.clone())
                                                     .evaluate_sequential()
                                                     .update_best_individual()
                                                     .do_(state::CroState::intermolecular_ineffective_collision_update())

--- a/src/heuristics/de.rs
+++ b/src/heuristics/de.rs
@@ -43,6 +43,7 @@ where
                 selection: selection::DEBest::new(y),
                 mutation: generation::mutation::DEMutation::new(y, f),
                 crossover: generation::recombination::DEBinomialCrossover::new(pc),
+                constraints: constraints::Saturation::new(),
                 replacement: replacement::IndividualPlus::new(),
             },
             termination,
@@ -56,6 +57,7 @@ pub struct Parameters<P> {
     pub selection: Box<dyn Component<P>>,
     pub mutation: Box<dyn Component<P>>,
     pub crossover: Box<dyn Component<P>>,
+    pub constraints: Box<dyn Component<P>>,
     pub replacement: Box<dyn Component<P>>,
 }
 
@@ -69,6 +71,7 @@ pub fn de<P: SingleObjectiveProblem>(
         selection,
         mutation,
         crossover,
+        constraints,
         replacement,
     } = params;
 
@@ -78,6 +81,7 @@ pub fn de<P: SingleObjectiveProblem>(
                 .do_(selection)
                 .do_(mutation)
                 .do_(crossover)
+                .do_(constraints)
                 .evaluate_sequential()
                 .update_best_individual()
                 .do_(replacement)

--- a/src/heuristics/es.rs
+++ b/src/heuristics/es.rs
@@ -40,6 +40,7 @@ where
             Parameters {
                 selection: selection::FullyRandom::new(lambda),
                 mutation: generation::mutation::FixedDeviationDelta::new(deviation),
+                constraints: constraints::Saturation::new(),
                 archive: None,
                 replacement: replacement::MuPlusLambda::new(population_size),
             },
@@ -53,6 +54,7 @@ where
 pub struct Parameters<P> {
     pub selection: Box<dyn Component<P>>,
     pub mutation: Box<dyn Component<P>>,
+    pub constraints: Box<dyn Component<P>>,
     pub archive: Option<Box<dyn Component<P>>>,
     pub replacement: Box<dyn Component<P>>,
 }
@@ -66,6 +68,7 @@ pub fn es<P: SingleObjectiveProblem>(
     let Parameters {
         selection,
         mutation,
+        constraints,
         archive,
         replacement,
     } = params;
@@ -75,6 +78,7 @@ pub fn es<P: SingleObjectiveProblem>(
             builder
                 .do_(selection)
                 .do_(mutation)
+                .do_(constraints)
                 .evaluate_sequential()
                 .update_best_individual()
                 .do_optional_(archive)

--- a/src/heuristics/ga.rs
+++ b/src/heuristics/ga.rs
@@ -49,6 +49,7 @@ where
                 crossover: generation::recombination::UniformCrossover::new_both(pc),
                 pm,
                 mutation: generation::mutation::BitflipMutation::new(rm),
+                constraints: misc::Noop::new(),
                 archive: None,
                 replacement: replacement::Generational::new(population_size),
             },
@@ -96,6 +97,7 @@ where
                 crossover: generation::recombination::UniformCrossover::new_both(pc),
                 pm,
                 mutation: generation::mutation::FixedDeviationDelta::new(deviation),
+                constraints: constraints::Saturation::new(),
                 archive: None,
                 replacement: replacement::Generational::new(population_size),
             },
@@ -111,6 +113,7 @@ pub struct Parameters<P> {
     pub crossover: Box<dyn Component<P>>,
     pub pm: f64,
     pub mutation: Box<dyn Component<P>>,
+    pub constraints: Box<dyn Component<P>>,
     pub archive: Option<Box<dyn Component<P>>>,
     pub replacement: Box<dyn Component<P>>,
 }
@@ -129,6 +132,7 @@ pub fn ga<P: SingleObjectiveProblem>(
         crossover,
         pm,
         mutation,
+        constraints,
         archive,
         replacement,
     } = params;
@@ -141,6 +145,7 @@ pub fn ga<P: SingleObjectiveProblem>(
                 .if_(branching::RandomChance::new(pm), |builder| {
                     builder.do_(mutation)
                 })
+                .do_(constraints)
                 .evaluate_sequential()
                 .update_best_individual()
                 .do_optional_(archive)

--- a/src/heuristics/iwo.rs
+++ b/src/heuristics/iwo.rs
@@ -63,6 +63,7 @@ where
                     final_deviation,
                     modulation_index,
                 ),
+                constraints: constraints::Saturation::new(),
             },
             termination,
             logger,
@@ -76,6 +77,7 @@ pub struct Parameters<P> {
     pub min_number_of_seeds: u32,
     pub max_number_of_seeds: u32,
     pub mutation: Box<dyn Component<P>>,
+    pub constraints: Box<dyn Component<P>>,
 }
 
 /// A generic single-objective Invasive Weed Optimization template.
@@ -89,6 +91,7 @@ pub fn iwo<P: SingleObjectiveProblem>(
         min_number_of_seeds,
         max_number_of_seeds,
         mutation,
+        constraints,
     } = params;
 
     Configuration::builder()
@@ -99,6 +102,7 @@ pub fn iwo<P: SingleObjectiveProblem>(
                     max_number_of_seeds,
                 ))
                 .do_(mutation)
+                .do_(constraints)
                 .evaluate_sequential()
                 .update_best_individual()
                 .do_(replacement::MuPlusLambda::new(max_population_size))

--- a/src/heuristics/ls.rs
+++ b/src/heuristics/ls.rs
@@ -36,6 +36,7 @@ where
             Parameters {
                 n_neighbors,
                 neighbors: generation::mutation::FixedDeviationDelta::new(deviation),
+                constraints: constraints::Saturation::new(),
             },
             termination,
             logger,
@@ -72,6 +73,7 @@ where
             Parameters {
                 n_neighbors,
                 neighbors: generation::mutation::SwapMutation::new(n_swap),
+                constraints: misc::Noop::new(),
             },
             termination,
             logger,
@@ -83,6 +85,7 @@ where
 pub struct Parameters<P> {
     pub n_neighbors: u32,
     pub neighbors: Box<dyn Component<P>>,
+    pub constraints: Box<dyn Component<P>>,
 }
 
 /// A generic single-objective Local Search template.
@@ -94,6 +97,7 @@ pub fn local_search<P: SingleObjectiveProblem>(
     let Parameters {
         n_neighbors,
         neighbors,
+        constraints,
     } = params;
 
     Configuration::builder()
@@ -101,6 +105,7 @@ pub fn local_search<P: SingleObjectiveProblem>(
             builder
                 .do_(selection::DuplicateSingle::new(n_neighbors))
                 .do_(neighbors)
+                .do_(constraints)
                 .evaluate_sequential()
                 .update_best_individual()
                 .do_(replacement::MuPlusLambda::new(1))

--- a/src/heuristics/pso.rs
+++ b/src/heuristics/pso.rs
@@ -42,6 +42,7 @@ where
             Parameters {
                 particle_init: state::PsoState::initializer(v_max),
                 particle_update: generation::swarm::PsoGeneration::new(weight, c_one, c_two, v_max),
+                constraints: constraints::Saturation::new(),
                 state_update: state::PsoState::updater(),
             },
             termination,
@@ -54,6 +55,7 @@ where
 pub struct Parameters<P> {
     particle_init: Box<dyn Component<P>>,
     particle_update: Box<dyn Component<P>>,
+    pub constraints: Box<dyn Component<P>>,
     state_update: Box<dyn Component<P>>,
 }
 
@@ -69,6 +71,7 @@ where
     let Parameters {
         particle_init,
         particle_update,
+        constraints,
         state_update,
     } = params;
 
@@ -77,6 +80,7 @@ where
         .while_(termination, |builder| {
             builder
                 .do_(particle_update)
+                .do_(constraints)
                 .evaluate_sequential()
                 .update_best_individual()
                 .do_(state_update)

--- a/src/heuristics/rw.rs
+++ b/src/heuristics/rw.rs
@@ -28,6 +28,7 @@ where
         .do_(random_walk(
             Parameters {
                 neighbor: generation::mutation::FixedDeviationDelta::new(deviation),
+                constraints: constraints::Saturation::new(),
             },
             termination,
             logger,
@@ -57,6 +58,7 @@ where
         .do_(random_walk(
             Parameters {
                 neighbor: generation::mutation::SwapMutation::new(n_swap),
+                constraints: misc::Noop::new(),
             },
             termination,
             logger,
@@ -66,6 +68,7 @@ where
 
 pub struct Parameters<P> {
     pub neighbor: Box<dyn Component<P>>,
+    pub constraints: Box<dyn Component<P>>,
 }
 
 /// A generic single-objective Random Search template.
@@ -77,13 +80,17 @@ pub fn random_walk<P>(
 where
     P: SingleObjectiveProblem,
 {
-    let Parameters { neighbor } = params;
+    let Parameters {
+        neighbor,
+        constraints,
+    } = params;
 
     Configuration::builder()
         .while_(termination, |builder| {
             builder
                 .do_(selection::All::new())
                 .do_(neighbor)
+                .do_(constraints)
                 .evaluate_sequential()
                 .update_best_individual()
                 .do_(replacement::Generational::new(1))


### PR DESCRIPTION
Closes #71 

All four techniques from #71 were implemented as components. I think adding a constraint handling component after a component which may violate the boundaries is more flexible than adding a field to pretty much every component that modifies solutions and handling it internally.

I'm not completely sure, but is probably a good idea to add a `contraints: Box<dyn Component<P>>` field to every heuristic template we have, @HeleNoir? Right now, this could also be handled by wrapping the specific component in a `Block`, where the second component is a constraint handling component, but this is not very pretty.