### PR TITLE
Do some renaming and refactors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 anyhow = "1.0.51"
 ciborium = "0.2.0"
 coco-rs = "0.5"
-derive_deref = "1.1.1"
+derive_more = { version = "0.99.17", features = ["deref", "deref_mut"]}
 embed-doc-image = "0.1.4"
 erased-serde = "0.3.16"
 float_eq = "0.7.0"

--- a/docs/framework.md
+++ b/docs/framework.md
@@ -61,9 +61,9 @@ Configuration::builder()
 Every component has to implement the [Component](components::Component) trait, which looks like this:
 ```ignore
 pub trait Component<P: Problem>: AnyComponent {
-    fn execute(&self, problem: &P, state: &mut State);
+    fn execute(&self, problem: &P, state: &mut State<P>);
 
-    fn initialize(&self, problem: &P, state: &mut State) { ... }
+    fn initialize(&self, problem: &P, state: &mut State<P>) { ... }
 }
 ```
 

--- a/docs/state.md
+++ b/docs/state.md
@@ -12,7 +12,7 @@ You would start by defining the state like this:
 
 ```rust
 use mahf::framework::state::CustomState;
-use mahf::derive_deref::{Deref, DerefMut};
+use mahf::derive_more::{Deref, DerefMut};
 use mahf::serde::Serialize;
 
 #[derive(Default, Debug, Deref, DerefMut, Serialize)]
@@ -32,7 +32,7 @@ Now you can use it in your component:
 
 The [CustomState] trait serves as a marker for custom state.
 You can take a look at its documentation to get a list off all state types provided by MAHF.
-If you have custom state representing a single value, it is recommended to also derive [Deref](derive_deref::Deref), [DerefMut](derive_deref::DerefMut) and [serde::Serialize].
+If you have custom state representing a single value, it is recommended to also derive [Deref](derive_more::Deref), [DerefMut](derive_more::DerefMut) and [serde::Serialize].
 
 ## Mutable Access
 

--- a/examples/bmf.rs
+++ b/examples/bmf.rs
@@ -1,32 +1,29 @@
-use mahf::framework::Random;
 use mahf::prelude::*;
+use problems::bmf::BenchmarkFunction;
 
-type P = problems::bmf::BenchmarkFunction;
-
-fn main() -> anyhow::Result<()> {
-    let problem = P::sphere(10);
-    let config = pso::real_pso(
+fn main() {
+    // Specify the problem: Sphere function with 10 dimensions.
+    let problem: BenchmarkFunction = BenchmarkFunction::sphere(/*dim: */ 10);
+    // Specify the metaheuristic: Particle Swarm Optimization (pre-implemented in MAHF).
+    let config: Configuration<BenchmarkFunction> = pso::real_pso(
+        /*params: */
         pso::RealProblemParameters {
-            num_particles: 100,
+            num_particles: 20,
             weight: 1.0,
             c_one: 1.0,
             c_two: 1.0,
             v_max: 1.0,
         },
-        termination::FixedIterations::new(500),
+        /*termination: */
+        termination::FixedIterations::new(/*max_iterations: */ 500)
+            & termination::DistanceToOpt::new(0.01),
     );
 
-    let state = config.optimize_with(&problem, |state| state.insert(Random::seeded(0)));
+    // Execute the metaheuristic on the problem with a random seed.
+    let state: State<BenchmarkFunction> = config.optimize(&problem);
 
-    println!(
-        "Found Fitness: {:?}",
-        state.best_objective_value::<P>().unwrap()
-    );
-    println!(
-        "Found Individual: {:?}",
-        state.best_individual::<P>().unwrap(),
-    );
+    // Print the results.
+    println!("Found Individual: {:?}", state.best_individual().unwrap());
+    println!("This took {} iterations.", state.iterations());
     println!("Global Optimum: {}", problem.known_optimum());
-
-    Ok(())
 }

--- a/examples/coco.rs
+++ b/examples/coco.rs
@@ -24,7 +24,7 @@ fn main() -> anyhow::Result<()> {
                 .with_common_extractors(trigger::Iteration::new(10))
                 .with(
                     trigger::Change::<common::Progress>::new(0.1),
-                    functions::auto::<common::Progress>,
+                    functions::auto::<common::Progress, _>,
                 )
                 .with(
                     trigger::Iteration::new(50),

--- a/examples/tsp.rs
+++ b/examples/tsp.rs
@@ -1,26 +1,43 @@
+use aco::ant_ops;
 use mahf::prelude::*;
+use problems::tsp::{self, SymmetricTsp};
+use tracking::{files, functions, trigger};
 
-type P = problems::tsp::SymmetricTsp;
-
-fn main() -> anyhow::Result<()> {
-    let problem = problems::tsp::Instances::BERLIN52.load();
-
-    let config = ils::permutation_iterated_local_search(
-        ils::PermutationProblemParameters {
-            local_search_params: ls::PermutationProblemParameters {
-                n_neighbors: 100,
-                n_swap: 10,
+fn main() {
+    // Specify the problem: TSPLIB instance Berlin52.
+    let problem: SymmetricTsp = tsp::Instances::BERLIN52.load();
+    // Specify the metaheuristic: Ant System.
+    let config: Configuration<SymmetricTsp> = Configuration::builder()
+        .do_(initialization::Empty::new())
+        .while_(
+            termination::FixedEvaluations::new(/*max_evaluations: */ 10_000),
+            |builder| {
+                builder
+                    .do_(ant_ops::AcoGeneration::new(
+                        /*num_ants: */ 20, /*alpha: */ 2.0, /*beta: */ 1.0,
+                        /*initial_pheromones: */ 0.0,
+                    ))
+                    .evaluate()
+                    .update_best_individual()
+                    .do_(ant_ops::AsPheromoneUpdate::new(
+                        /*evaporation: */ 0.2, /*decay_coefficient: */ 1.0,
+                    ))
+                    .do_(tracking::Logger::new())
             },
-            local_search_termination: termination::FixedIterations::new(100),
-        },
-        termination::FixedIterations::new(10),
-    )
-    .into_builder()
-    .assert(|state| state.population_stack::<P>().current().len() == 1)
-    .single_objective_summary()
-    .build();
+        )
+        .build();
 
-    config.optimize(&problem);
+    // Execute the metaheuristic on the problem.
+    let state: State<SymmetricTsp> = config.optimize_with(&problem, |state| {
+        // Set the seed to 42.
+        state.insert(Random::seeded(42));
+        // Log the best individual every 50 iterations.
+        state.insert(
+            tracking::LogSet::<SymmetricTsp>::new()
+                .with(trigger::Iteration::new(50), functions::best_individual),
+        );
+    });
 
-    Ok(())
+    // Save the log to file "aco_berlin52.log".
+    files::write_log_file("aco_berlin52.log", state.log()).unwrap();
 }

--- a/src/components/generation/mutation.rs
+++ b/src/components/generation/mutation.rs
@@ -39,12 +39,12 @@ where
         &self,
         population: &mut Vec<P::Encoding>,
         _problem: &P,
-        state: &mut State,
+        state: &mut State<P>,
     ) {
         let distribution = rand_distr::Normal::new(0.0, self.deviation).unwrap();
 
-        for solution in population.iter_mut() {
-            for x in solution.iter_mut() {
+        for solution in population {
+            for x in solution {
                 *x += distribution.sample(state.random_mut());
             }
         }
@@ -99,13 +99,13 @@ where
         &self,
         population: &mut Vec<P::Encoding>,
         _problem: &P,
-        state: &mut State,
+        state: &mut State<P>,
     ) {
         let deviation = self.deviation(state.get_value::<Progress>());
         let distribution = rand_distr::Normal::new(0.0, deviation).unwrap();
 
-        for solution in population.iter_mut() {
-            for x in solution.iter_mut() {
+        for solution in population {
+            for x in solution {
                 *x += distribution.sample(state.random_mut());
             }
         }
@@ -155,7 +155,7 @@ where
         &self,
         population: &mut Vec<P::Encoding>,
         problem: &P,
-        state: &mut State,
+        state: &mut State<P>,
     ) {
         let rng = state.random_mut();
 
@@ -180,7 +180,7 @@ mod uniform_mutation {
     fn all_mutated() {
         let problem = BenchmarkFunction::sphere(3);
         let comp = UniformMutation { rm: 1.0 };
-        let mut state = State::new_root();
+        let mut state = State::new();
         state.insert(Random::testing());
         let mut population = vec![vec![0.1, 0.2, 0.4], vec![0.2, 0.3, 0.6]];
         let parents_length = population.len();
@@ -223,13 +223,13 @@ where
         &self,
         population: &mut Vec<P::Encoding>,
         _problem: &P,
-        state: &mut State,
+        state: &mut State<P>,
     ) {
         let distribution = rand_distr::Normal::new(0.0, self.deviation).unwrap();
         let rng = state.random_mut();
 
-        for solution in population.iter_mut() {
-            for x in solution.iter_mut() {
+        for solution in population {
+            for x in solution {
                 if rng.gen_bool(self.rm) {
                     *x += distribution.sample(rng);
                 }
@@ -252,7 +252,7 @@ mod gaussian_mutation {
             rm: 1.0,
             deviation: 0.1,
         };
-        let mut state = State::new_root();
+        let mut state = State::new();
         state.insert(Random::testing());
         let mut population = vec![vec![0.1, 0.2, 0.4], vec![0.2, 0.3, 0.6]];
         let parents_length = population.len();
@@ -292,12 +292,12 @@ where
         &self,
         population: &mut Vec<P::Encoding>,
         _problem: &P,
-        state: &mut State,
+        state: &mut State<P>,
     ) {
         let rng = state.random_mut();
 
-        for solution in population.iter_mut() {
-            for x in solution.iter_mut() {
+        for solution in population {
+            for x in solution {
                 if rng.gen_bool(self.rm) {
                     *x = !*x;
                 }
@@ -330,7 +330,7 @@ where
         &self,
         population: &mut Vec<P::Encoding>,
         _problem: &P,
-        state: &mut State,
+        state: &mut State<P>,
     ) {
         assert!(self.n_swap > 1);
         let rng = state.random_mut();
@@ -364,7 +364,7 @@ mod swap_mutation {
     fn all_mutated() {
         let problem = BenchmarkFunction::sphere(3);
         let comp = SwapMutation { n_swap: 2 };
-        let mut state = State::new_root();
+        let mut state = State::new();
         state.insert(Random::testing());
         let mut population = vec![vec![0.1, 0.2, 0.4, 0.5, 0.9], vec![0.2, 0.3, 0.6, 0.7, 0.8]];
         let parents_length = population.len();
@@ -401,7 +401,7 @@ where
         &self,
         population: &mut Vec<P::Encoding>,
         _problem: &P,
-        state: &mut State,
+        state: &mut State<P>,
     ) {
         let rng = state.random_mut();
 
@@ -422,7 +422,7 @@ mod scramble_mutation {
     fn all_mutated() {
         let problem = BenchmarkFunction::sphere(3);
         let comp = ScrambleMutation;
-        let mut state = State::new_root();
+        let mut state = State::new();
         state.insert(Random::testing());
         let mut population = vec![vec![0.1, 0.2, 0.4, 0.5, 0.9], vec![0.2, 0.3, 0.6, 0.7, 0.8]];
         let parents_length = population.len();
@@ -459,7 +459,7 @@ where
         &self,
         population: &mut Vec<P::Encoding>,
         _problem: &P,
-        state: &mut State,
+        state: &mut State<P>,
     ) {
         let rng = state.random_mut();
 
@@ -481,7 +481,7 @@ mod insertion_mutation {
     fn all_mutated() {
         let problem = BenchmarkFunction::sphere(3);
         let comp = InsertionMutation;
-        let mut state = State::new_root();
+        let mut state = State::new();
         state.insert(Random::testing());
         let mut population = vec![vec![0.1, 0.2, 0.4, 0.5, 0.9], vec![0.2, 0.3, 0.6, 0.7, 0.8]];
         let parents_length = population.len();
@@ -518,7 +518,7 @@ where
         &self,
         population: &mut Vec<P::Encoding>,
         _problem: &P,
-        state: &mut State,
+        state: &mut State<P>,
     ) {
         let rng = state.random_mut();
         for solution in population.iter_mut() {
@@ -543,7 +543,7 @@ mod inversion_mutation {
     fn all_mutated() {
         let problem = BenchmarkFunction::sphere(3);
         let comp = InversionMutation;
-        let mut state = State::new_root();
+        let mut state = State::new();
         state.insert(Random::testing());
         let mut population = vec![vec![0.1, 0.2, 0.4, 0.5, 0.9], vec![0.2, 0.3, 0.6, 0.7, 0.8]];
         let parents_length = population.len();
@@ -582,7 +582,7 @@ where
         &self,
         population: &mut Vec<P::Encoding>,
         _problem: &P,
-        state: &mut State,
+        state: &mut State<P>,
     ) {
         let rng = state.random_mut();
         for solution in population.iter_mut() {
@@ -614,7 +614,7 @@ mod translocation_mutation {
     fn all_mutated() {
         let problem = BenchmarkFunction::sphere(3);
         let comp = TranslocationMutation;
-        let mut state = State::new_root();
+        let mut state = State::new();
         state.insert(Random::testing());
         let mut population = vec![vec![0.1, 0.2, 0.4, 0.5, 0.9], vec![0.2, 0.3, 0.6, 0.7, 0.8]];
         let parents_length = population.len();
@@ -657,7 +657,7 @@ where
         &self,
         population: &mut Vec<P::Encoding>,
         problem: &P,
-        _state: &mut State,
+        _state: &mut State<P>,
     ) {
         assert_eq!(population.len() % (self.y * 2 + 1), 0);
 
@@ -706,7 +706,7 @@ mod de_mutation {
         let problem = BenchmarkFunction::sphere(3);
         let y = 1;
         let comp = DEMutation { y, f: 1. };
-        let mut state = State::new_root();
+        let mut state = State::new();
         state.insert(Random::testing());
         let mut population = vec![
             vec![0.1, 0.2, 0.4, 0.5, 0.9],
@@ -743,15 +743,15 @@ where
     P: Problem<Encoding = Vec<D>>,
     D: Clone,
 {
-    fn initialize(&self, problem: &P, state: &mut State) {
+    fn initialize(&self, problem: &P, state: &mut State<P>) {
         self.mutation.initialize(problem, state);
     }
 
-    fn execute(&self, problem: &P, state: &mut State) {
+    fn execute(&self, problem: &P, state: &mut State<P>) {
         let mut partial_population = Vec::new();
         let mut population_indices = Vec::new();
 
-        let mut population: Vec<Individual<P>> = state.population_stack_mut::<P>().pop();
+        let mut population = state.populations_mut().pop();
 
         // Decide which indices/dimensions to mutate,
         // and keep indices and solution from selected indices
@@ -777,9 +777,9 @@ where
         }
 
         // Mutate the partial solutions
-        state.population_stack_mut::<P>().push(partial_population);
+        state.populations_mut().push(partial_population);
         self.mutation.execute(problem, state);
-        let partial_population = state.population_stack_mut::<P>().pop();
+        let partial_population = state.populations_mut().pop();
 
         // Insert mutated dimensions into original solutions
         for (indices, solution, partial) in
@@ -792,6 +792,6 @@ where
         }
 
         // Push partially mutated population back
-        state.population_stack_mut::<P>().push(population);
+        state.populations_mut().push(population);
     }
 }

--- a/src/components/generation/recombination.rs
+++ b/src/components/generation/recombination.rs
@@ -61,7 +61,7 @@ where
         parents: Vec<Vec<D>>,
         offspring: &mut Vec<Vec<D>>,
         _problem: &P,
-        state: &mut State,
+        state: &mut State<P>,
     ) {
         let dim: usize = parents
             .iter()
@@ -120,7 +120,7 @@ mod npoint_crossover {
             points: 3,
             keep_both: true,
         };
-        let mut state = State::new_root();
+        let mut state = State::new();
         state.insert(Random::testing());
         let population = vec![
             vec![0.1, 0.2, 0.4, 0.5, 0.9],
@@ -179,7 +179,7 @@ where
         parents: Vec<Vec<D>>,
         offspring: &mut Vec<Vec<D>>,
         _problem: &P,
-        state: &mut State,
+        state: &mut State<P>,
     ) {
         for pairs in parents.chunks(2) {
             if pairs.len() == 1 {
@@ -226,7 +226,7 @@ mod uniform_crossover {
             pc: 1.0,
             keep_both: true,
         };
-        let mut state = State::new_root();
+        let mut state = State::new();
         state.insert(Random::testing());
         let population = vec![
             vec![0.1, 0.2, 0.4, 0.5, 0.9],
@@ -269,7 +269,7 @@ where
         parents: Vec<Vec<D>>,
         offspring: &mut Vec<Vec<D>>,
         _problem: &P,
-        state: &mut State,
+        state: &mut State<P>,
     ) {
         for pairs in parents.chunks(2) {
             if pairs.len() == 1 {
@@ -325,7 +325,7 @@ mod cycle_crossover {
     fn all_recombined() {
         let problem = BenchmarkFunction::sphere(3);
         let comp = CycleCrossover { pc: 1.0 };
-        let mut state = State::new_root();
+        let mut state = State::new();
         state.insert(Random::testing());
         let population = vec![
             vec![8.0, 4.0, 7.0, 3.0, 6.0, 2.0, 5.0, 1.0, 9.0, 0.0],
@@ -357,12 +357,12 @@ impl<P> Component<P> for DEBinomialCrossover
 where
     P: Problem<Encoding = Vec<f64>> + VectorProblem,
 {
-    fn execute(&self, problem: &P, state: &mut State) {
+    fn execute(&self, problem: &P, state: &mut State<P>) {
         let mut mut_state = state.get_states_mut();
-        let stack = mut_state.population_stack_mut::<P>();
+        let populations = mut_state.populations_mut();
 
-        let mut mutations = stack.pop();
-        let bases = stack.current();
+        let mut mutations = populations.pop();
+        let bases = populations.current();
 
         let rng = mut_state.random_mut();
 
@@ -379,14 +379,14 @@ where
             }
         }
 
-        stack.push(mutations);
+        populations.push(mutations);
     }
 }
 #[cfg(test)]
 mod de_binomial_crossover {
     use crate::framework::{Individual, Random};
     use crate::problems::bmf::BenchmarkFunction;
-    use crate::state::common::Population;
+    use crate::state::common::Populations;
 
     use super::*;
 
@@ -394,10 +394,10 @@ mod de_binomial_crossover {
     fn all_recombined() {
         let problem = BenchmarkFunction::sphere(3);
         let comp = DEBinomialCrossover { pc: 1.0 };
-        let mut state = State::new_root();
+        let mut state = State::new();
         state.insert(Random::testing());
 
-        let mut stack = Population::<BenchmarkFunction>::new();
+        let mut stack = Populations::<BenchmarkFunction>::new();
         stack.push(
             vec![
                 vec![8.0, 4.0, 7.0, 3.0, 6.0, 2.0, 5.0, 1.0, 9.0, 0.0],
@@ -422,7 +422,7 @@ mod de_binomial_crossover {
         comp.initialize(&problem, &mut state);
         comp.execute(&problem, &mut state);
 
-        let stack = state.population_stack_mut::<BenchmarkFunction>();
+        let stack = state.populations_mut();
 
         let offspring = stack.pop();
         let parents = stack.current();
@@ -450,12 +450,12 @@ impl<P> Component<P> for DEExponentialCrossover
 where
     P: Problem<Encoding = Vec<f64>> + VectorProblem,
 {
-    fn execute(&self, problem: &P, state: &mut State) {
+    fn execute(&self, problem: &P, state: &mut State<P>) {
         let mut mut_state = state.get_states_mut();
-        let stack = mut_state.population_stack_mut::<P>();
+        let populations = mut_state.populations_mut();
 
-        let mut mutations = stack.pop();
-        let bases = stack.current();
+        let mut mutations = populations.pop();
+        let bases = populations.current();
 
         let rng = mut_state.random_mut();
 
@@ -476,14 +476,14 @@ where
             }
         }
 
-        stack.push(mutations);
+        populations.push(mutations);
     }
 }
 #[cfg(test)]
 mod de_exponential_crossover {
     use crate::framework::{Individual, Random};
     use crate::problems::bmf::BenchmarkFunction;
-    use crate::state::common::Population;
+    use crate::state::common::Populations;
 
     use super::*;
 
@@ -491,10 +491,10 @@ mod de_exponential_crossover {
     fn all_recombined() {
         let problem = BenchmarkFunction::sphere(3);
         let comp = DEExponentialCrossover { pc: 1.0 };
-        let mut state = State::new_root();
+        let mut state = State::new();
         state.insert(Random::testing());
 
-        let mut stack = Population::<BenchmarkFunction>::new();
+        let mut stack = Populations::<BenchmarkFunction>::new();
         stack.push(
             vec![
                 vec![8.0, 4.0, 7.0, 3.0, 6.0, 2.0, 5.0, 1.0, 9.0, 0.0],
@@ -519,7 +519,7 @@ mod de_exponential_crossover {
         comp.initialize(&problem, &mut state);
         comp.execute(&problem, &mut state);
 
-        let stack = state.population_stack_mut::<BenchmarkFunction>();
+        let stack = state.populations_mut();
 
         let offspring = stack.pop();
         let parents = stack.current();

--- a/src/components/generation/swarm.rs
+++ b/src/components/generation/swarm.rs
@@ -41,11 +41,11 @@ impl<P> Component<P> for PsoGeneration
 where
     P: SingleObjectiveProblem<Encoding = Vec<f64>>,
 {
-    fn initialize(&self, _problem: &P, state: &mut State) {
-        state.require::<PsoState<P>>();
+    fn initialize(&self, _problem: &P, state: &mut State<P>) {
+        state.require::<Self, PsoState<P>>();
     }
 
-    fn execute(&self, _problem: &P, state: &mut State) {
+    fn execute(&self, _problem: &P, state: &mut State<P>) {
         let &Self {
             weight,
             c_one,
@@ -54,7 +54,7 @@ where
         } = self;
 
         let mut offspring = Vec::new();
-        let mut parents = state.population_stack_mut::<P>().pop();
+        let mut parents = state.populations_mut().pop();
 
         let rng = state.random_mut();
         let rng_iter = |rng: &mut Random| {
@@ -90,6 +90,6 @@ where
             offspring.push(Individual::<P>::new_unevaluated(x));
         }
 
-        state.population_stack_mut().push(offspring);
+        state.populations_mut().push(offspring);
     }
 }

--- a/src/components/initialization.rs
+++ b/src/components/initialization.rs
@@ -15,7 +15,7 @@ use crate::{
 ///
 /// Types implementing this trait can implement [Component] by wrapping the type in a [Initializer].
 pub trait Initialization<P: Problem>: AnyComponent {
-    fn initialize_population(&self, problem: &P, state: &mut State) -> Vec<Individual<P>>;
+    fn initialize_population(&self, problem: &P, state: &mut State<P>) -> Vec<Individual<P>>;
 }
 
 #[derive(Serialize, Clone)]
@@ -26,9 +26,9 @@ where
     P: Problem,
     T: AnyComponent + Initialization<P> + Serialize + Clone,
 {
-    fn execute(&self, problem: &P, state: &mut State) {
+    fn execute(&self, problem: &P, state: &mut State<P>) {
         let population = self.0.initialize_population(problem, state);
-        state.population_stack_mut().push(population);
+        state.populations_mut().push(population);
     }
 }
 
@@ -44,7 +44,7 @@ impl Empty {
     }
 }
 impl<P: Problem> Initialization<P> for Empty {
-    fn initialize_population(&self, _problem: &P, _state: &mut State) -> Vec<Individual<P>> {
+    fn initialize_population(&self, _problem: &P, _state: &mut State<P>) -> Vec<Individual<P>> {
         Vec::new()
     }
 }
@@ -94,7 +94,7 @@ where
     D: SampleUniform + Clone + PartialOrd + 'static,
     P: Problem<Encoding = Vec<D>> + LimitedVectorProblem<T = D>,
 {
-    fn initialize_population(&self, problem: &P, state: &mut State) -> Vec<Individual<P>> {
+    fn initialize_population(&self, problem: &P, state: &mut State<P>) -> Vec<Individual<P>> {
         let population_size = self.initial_population_size.unwrap();
         self.random_spread(problem, state.random_mut(), population_size)
             .into_iter()
@@ -142,7 +142,7 @@ impl<P> Initialization<P> for RandomPermutation
 where
     P: Problem<Encoding = Vec<usize>> + VectorProblem<T = usize>,
 {
-    fn initialize_population(&self, problem: &P, state: &mut State) -> Vec<Individual<P>> {
+    fn initialize_population(&self, problem: &P, state: &mut State<P>) -> Vec<Individual<P>> {
         let population_size = self.initial_population_size.unwrap();
         self.random_permutation(problem, state.random_mut(), population_size)
             .into_iter()
@@ -209,7 +209,7 @@ impl<P> Initialization<P> for RandomBitstring
 where
     P: Problem<Encoding = Vec<bool>> + VectorProblem<T = bool>,
 {
-    fn initialize_population(&self, problem: &P, state: &mut State) -> Vec<Individual<P>> {
+    fn initialize_population(&self, problem: &P, state: &mut State<P>) -> Vec<Individual<P>> {
         let population_size = self.initial_population_size.unwrap();
         self.random_bitstring(problem, state.random_mut(), population_size)
             .into_iter()

--- a/src/conditions/branching.rs
+++ b/src/conditions/branching.rs
@@ -22,7 +22,7 @@ impl<P> Condition<P> for RandomChance
 where
     P: Problem,
 {
-    fn evaluate(&self, _problem: &P, state: &mut State) -> bool {
+    fn evaluate(&self, _problem: &P, state: &mut State<P>) -> bool {
         state.random_mut().gen_bool(self.p)
     }
 }
@@ -44,8 +44,8 @@ impl<P> Condition<P> for LessThanNIndividuals
 where
     P: Problem,
 {
-    fn evaluate(&self, _problem: &P, state: &mut State) -> bool {
-        state.population_stack::<P>().current().len() < self.n
+    fn evaluate(&self, _problem: &P, state: &mut State<P>) -> bool {
+        state.populations().current().len() < self.n
     }
 }
 
@@ -67,13 +67,13 @@ impl<P> Condition<P> for DecompositionCriterion
 where
     P: Problem,
 {
-    fn evaluate(&self, _problem: &P, state: &mut State) -> bool {
+    fn evaluate(&self, _problem: &P, state: &mut State<P>) -> bool {
         let mut mut_state = state.get_states_mut();
         let cro_state = mut_state.get::<state::CroState<P>>();
-        let stack = mut_state.population_stack::<P>();
+        let populations = mut_state.populations();
 
-        let selected = stack.peek(0).first().unwrap();
-        let population = stack.peek(1);
+        let selected = populations.peek(0).first().unwrap();
+        let population = populations.peek(1);
 
         let selected_index = population.iter().position(|i| i == selected).unwrap();
         let molecule = &cro_state.molecules[selected_index];
@@ -100,13 +100,13 @@ impl<P> Condition<P> for SynthesisCriterion
 where
     P: Problem,
 {
-    fn evaluate(&self, _problem: &P, state: &mut State) -> bool {
+    fn evaluate(&self, _problem: &P, state: &mut State<P>) -> bool {
         let mut mut_state = state.get_states_mut();
         let cro_state = mut_state.get::<state::CroState<P>>();
-        let stack = mut_state.population_stack::<P>();
+        let populations = mut_state.populations();
 
-        let [s1, s2] = TryInto::<&[_; 2]>::try_into(stack.peek(0)).unwrap();
-        let population = stack.peek(1);
+        let [s1, s2] = TryInto::<&[_; 2]>::try_into(populations.peek(0)).unwrap();
+        let population = populations.peek(1);
 
         let s1_index = population.iter().position(|i| i == s1).unwrap();
         let s1_molecule = &cro_state.molecules[s1_index];

--- a/src/framework/components.rs
+++ b/src/framework/components.rs
@@ -127,8 +127,8 @@ impl<P: Problem> Component<P> for Loop<P> {
     fn initialize(&self, problem: &P, state: &mut State<P>) {
         state.insert(common::Iterations(0));
 
-        self.body.initialize(problem, state);
         self.condition.initialize(problem, state);
+        self.body.initialize(problem, state);
     }
 
     fn execute(&self, problem: &P, state: &mut State<P>) {

--- a/src/framework/components.rs
+++ b/src/framework/components.rs
@@ -27,8 +27,8 @@ trait_set! {
 /// change during a run. All mutable state has to be stored in the [State].
 pub trait Component<P: Problem>: AnyComponent {
     #[allow(unused_variables)]
-    fn initialize(&self, problem: &P, state: &mut State) {}
-    fn execute(&self, problem: &P, state: &mut State);
+    fn initialize(&self, problem: &P, state: &mut State<P>) {}
+    fn execute(&self, problem: &P, state: &mut State<P>);
 }
 erased_serde::serialize_trait_object!(<P: Problem> Component<P>);
 dyn_clone::clone_trait_object!(<P: Problem> Component<P>);
@@ -48,11 +48,11 @@ pub struct Scope<P: Problem> {
     body: Box<dyn Component<P>>,
 
     #[serde(skip)]
-    init: fn(&mut State),
+    init: fn(&mut State<P>),
 }
 
 impl<P: Problem> Component<P> for Scope<P> {
-    fn execute(&self, problem: &P, state: &mut State) {
+    fn execute(&self, problem: &P, state: &mut State<P>) {
         state.with_substate(|state| {
             (self.init)(state);
             self.body.initialize(problem, state);
@@ -72,7 +72,7 @@ impl<P: Problem> Scope<P> {
 
     /// Creates a new [Scope] while overriding some state.
     pub fn new_with(
-        init: fn(&mut State),
+        init: fn(&mut State<P>),
         body: Vec<Box<dyn Component<P>>>,
     ) -> Box<dyn Component<P>> {
         let body = Block::new(body);
@@ -90,13 +90,13 @@ impl<P: Problem> Scope<P> {
 pub struct Block<P: Problem>(Vec<Box<dyn Component<P>>>);
 
 impl<P: Problem> Component<P> for Block<P> {
-    fn initialize(&self, problem: &P, state: &mut State) {
+    fn initialize(&self, problem: &P, state: &mut State<P>) {
         for component in &self.0 {
             component.initialize(problem, state);
         }
     }
 
-    fn execute(&self, problem: &P, state: &mut State) {
+    fn execute(&self, problem: &P, state: &mut State<P>) {
         for component in &self.0 {
             component.execute(problem, state);
         }
@@ -124,14 +124,14 @@ pub struct Loop<P: Problem> {
 }
 
 impl<P: Problem> Component<P> for Loop<P> {
-    fn initialize(&self, problem: &P, state: &mut State) {
+    fn initialize(&self, problem: &P, state: &mut State<P>) {
         state.insert(common::Iterations(0));
 
-        self.condition.initialize(problem, state);
         self.body.initialize(problem, state);
+        self.condition.initialize(problem, state);
     }
 
-    fn execute(&self, problem: &P, state: &mut State) {
+    fn execute(&self, problem: &P, state: &mut State<P>) {
         self.condition.initialize(problem, state);
         while self.condition.evaluate(problem, state) {
             self.body.execute(problem, state);
@@ -161,7 +161,7 @@ pub struct Branch<P: Problem> {
 }
 
 impl<P: Problem> Component<P> for Branch<P> {
-    fn initialize(&self, problem: &P, state: &mut State) {
+    fn initialize(&self, problem: &P, state: &mut State<P>) {
         self.condition.initialize(problem, state);
         self.if_body.initialize(problem, state);
         if let Some(else_body) = &self.else_body {
@@ -169,7 +169,7 @@ impl<P: Problem> Component<P> for Branch<P> {
         }
     }
 
-    fn execute(&self, problem: &P, state: &mut State) {
+    fn execute(&self, problem: &P, state: &mut State<P>) {
         if self.condition.evaluate(problem, state) {
             self.if_body.execute(problem, state);
         } else if let Some(else_body) = &self.else_body {

--- a/src/framework/conditions.rs
+++ b/src/framework/conditions.rs
@@ -10,10 +10,10 @@ use crate::{framework::components::AnyComponent, problems::Problem, state::State
 /// but `evaluate` replaces `execute` and returns a `bool`.
 ///
 /// These can be combined using binary AND and OR (`|` and `&`).
-pub trait Condition<P>: AnyComponent {
+pub trait Condition<P: Problem>: AnyComponent {
     #[allow(unused_variables)]
-    fn initialize(&self, problem: &P, state: &mut State) {}
-    fn evaluate(&self, problem: &P, state: &mut State) -> bool;
+    fn initialize(&self, problem: &P, state: &mut State<P>) {}
+    fn evaluate(&self, problem: &P, state: &mut State<P>) -> bool;
 }
 erased_serde::serialize_trait_object!(<P: Problem> Condition<P>);
 dyn_clone::clone_trait_object!(<P: Problem> Condition<P>);
@@ -29,13 +29,13 @@ impl<P: Problem> And<P> {
     }
 }
 impl<P: Problem> Condition<P> for And<P> {
-    fn initialize(&self, problem: &P, state: &mut State) {
+    fn initialize(&self, problem: &P, state: &mut State<P>) {
         for condition in self.0.iter() {
             condition.initialize(problem, state);
         }
     }
 
-    fn evaluate(&self, problem: &P, state: &mut State) -> bool {
+    fn evaluate(&self, problem: &P, state: &mut State<P>) -> bool {
         self.0
             .iter()
             .all(|condition| condition.evaluate(problem, state))
@@ -60,13 +60,13 @@ impl<P: Problem> Or<P> {
     }
 }
 impl<P: Problem> Condition<P> for Or<P> {
-    fn initialize(&self, problem: &P, state: &mut State) {
+    fn initialize(&self, problem: &P, state: &mut State<P>) {
         for condition in self.0.iter() {
             condition.initialize(problem, state);
         }
     }
 
-    fn evaluate(&self, problem: &P, state: &mut State) -> bool {
+    fn evaluate(&self, problem: &P, state: &mut State<P>) -> bool {
         self.0
             .iter()
             .any(|condition| condition.evaluate(problem, state))
@@ -91,11 +91,11 @@ impl<P: Problem> Not<P> {
     }
 }
 impl<P: Problem> Condition<P> for Not<P> {
-    fn initialize(&self, problem: &P, state: &mut State) {
+    fn initialize(&self, problem: &P, state: &mut State<P>) {
         self.0.initialize(problem, state);
     }
 
-    fn evaluate(&self, problem: &P, state: &mut State) -> bool {
+    fn evaluate(&self, problem: &P, state: &mut State<P>) -> bool {
         !self.0.evaluate(problem, state)
     }
 }

--- a/src/framework/objective.rs
+++ b/src/framework/objective.rs
@@ -5,6 +5,7 @@ use std::fmt;
 use trait_set::trait_set;
 
 trait_set! {
+    /// Collection of traits required by every objective.
     pub trait AnyObjective = fmt::Debug + Clone + Eq + Any + PartialOrd + Send + Sync
 }
 

--- a/src/heuristics/aco.rs
+++ b/src/heuristics/aco.rs
@@ -135,7 +135,7 @@ pub fn aco<P: SingleObjectiveProblem>(
         .build_component()
 }
 
-mod ant_ops {
+pub mod ant_ops {
     use crate::state::PheromoneMatrix;
     use crate::{
         framework::{components::*, Individual, Random, SingleObjective},
@@ -167,14 +167,14 @@ mod ant_ops {
         }
     }
     impl Component<SymmetricTsp> for AcoGeneration {
-        fn initialize(&self, problem: &SymmetricTsp, state: &mut State) {
+        fn initialize(&self, problem: &SymmetricTsp, state: &mut State<SymmetricTsp>) {
             state.insert(PheromoneMatrix::new(
                 problem.dimension,
                 self.default_pheromones,
             ));
         }
 
-        fn execute(&self, problem: &SymmetricTsp, state: &mut State) {
+        fn execute(&self, problem: &SymmetricTsp, state: &mut State<SymmetricTsp>) {
             let (pm, rng) = state.get_multiple_mut::<(PheromoneMatrix, Random)>();
             let mut routes = Vec::new();
 
@@ -222,7 +222,7 @@ mod ant_ops {
                 .into_iter()
                 .map(Individual::<SymmetricTsp>::new_unevaluated)
                 .collect();
-            *state.population_stack_mut().current_mut() = population;
+            *state.populations_mut().current_mut() = population;
         }
     }
 
@@ -240,14 +240,14 @@ mod ant_ops {
         }
     }
     impl Component<SymmetricTsp> for AsPheromoneUpdate {
-        fn initialize(&self, _problem: &SymmetricTsp, state: &mut State) {
-            state.require::<PheromoneMatrix>();
+        fn initialize(&self, _problem: &SymmetricTsp, state: &mut State<SymmetricTsp>) {
+            state.require::<Self, PheromoneMatrix>();
         }
 
-        fn execute(&self, _problem: &SymmetricTsp, state: &mut State) {
+        fn execute(&self, _problem: &SymmetricTsp, state: &mut State<SymmetricTsp>) {
             let mut mut_state = state.get_states_mut();
             let pm = mut_state.get_mut::<PheromoneMatrix>();
-            let population = mut_state.population_stack::<SymmetricTsp>().current();
+            let population = mut_state.populations().current();
 
             // Evaporation
             *pm *= 1.0 - self.evaporation;
@@ -289,14 +289,14 @@ mod ant_ops {
         }
     }
     impl Component<SymmetricTsp> for MinMaxPheromoneUpdate {
-        fn initialize(&self, _problem: &SymmetricTsp, state: &mut State) {
-            state.require::<PheromoneMatrix>();
+        fn initialize(&self, _problem: &SymmetricTsp, state: &mut State<SymmetricTsp>) {
+            state.require::<Self, PheromoneMatrix>();
         }
 
-        fn execute(&self, _problem: &SymmetricTsp, state: &mut State) {
+        fn execute(&self, _problem: &SymmetricTsp, state: &mut State<SymmetricTsp>) {
             let mut mut_state = state.get_states_mut();
             let pm = mut_state.get_mut::<PheromoneMatrix>();
-            let population = mut_state.population_stack::<SymmetricTsp>().current();
+            let population = mut_state.populations().current();
 
             // Evaporation
             *pm *= 1.0 - self.evaporation;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ pub mod utils;
 pub mod testing;
 
 // re-exports
-pub use derive_deref;
+pub use derive_more;
 pub use float_eq;
 pub use rand;
 pub use rand_distr;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -5,5 +5,7 @@ pub use crate::{
     conditions::*,
     framework::{self, Configuration, Random},
     heuristics::*,
-    problems, tracking,
+    problems,
+    state::{self, State},
+    tracking,
 };

--- a/src/problems/coco_bound/mod.rs
+++ b/src/problems/coco_bound/mod.rs
@@ -1,9 +1,9 @@
 use std::ops::RangeInclusive;
 
 use crate::{
-    framework::SingleObjective,
+    framework::{Individual, SingleObjective},
     problems::{self, Evaluator},
-    state::common::EvaluatorInstance,
+    state::{common::EvaluatorInstance, State},
 };
 
 pub use coco_rs::{Problem, Suite};
@@ -92,8 +92,8 @@ impl Evaluator for CocoEvaluator<'_> {
     fn evaluate(
         &mut self,
         _problem: &Self::Problem,
-        _state: &mut crate::state::State,
-        individuals: &mut [crate::framework::Individual<Self::Problem>],
+        _state: &mut State<Self::Problem>,
+        individuals: &mut [Individual<Self::Problem>],
     ) {
         for individual in individuals {
             let mut out = [0.0];

--- a/src/problems/coco_bound/suits.rs
+++ b/src/problems/coco_bound/suits.rs
@@ -33,7 +33,7 @@ pub fn evaluate_suite(
     mut suite: Suite,
     configuration: Configuration<CocoInstance>,
     output_dir: &str,
-    setup: impl Fn(&mut State) + Send + Sync,
+    setup: impl Fn(&mut State<CocoInstance>) + Send + Sync,
 ) -> anyhow::Result<()> {
     #[allow(unused_variables)]
     let num_threads = 1;
@@ -103,9 +103,7 @@ pub fn evaluate_suite(
                             let log = state.get::<Log>();
                             files::write_log_file(log_file, log)?;
 
-                            let target_hit = if let Some(fitness) =
-                                state.best_objective_value::<CocoInstance>()
-                            {
+                            let target_hit = if let Some(fitness) = state.best_objective_value() {
                                 instance.target_hit(*fitness)
                             } else {
                                 false

--- a/src/problems/mod.rs
+++ b/src/problems/mod.rs
@@ -54,7 +54,7 @@ pub trait Evaluator: Send {
     fn evaluate(
         &mut self,
         problem: &Self::Problem,
-        state: &mut State,
+        state: &mut State<Self::Problem>,
         individuals: &mut [Individual<Self::Problem>],
     );
 }

--- a/src/problems/tsp/symmetric.rs
+++ b/src/problems/tsp/symmetric.rs
@@ -1,12 +1,12 @@
 //! This module contains instances of the symmetric traveling salesman problem.
 
 use crate::{
-    framework::SingleObjective,
+    framework::{Individual, SingleObjective},
     problems::{
         tsp::{Coordinates, Dimension, DistanceMeasure, Edge, Route},
         Evaluator, Problem, VectorProblem,
     },
-    state::common::EvaluatorInstance,
+    state::{common::EvaluatorInstance, State},
 };
 use anyhow::{anyhow, Error, Result};
 use pest_consume::Parser;
@@ -319,8 +319,8 @@ impl Evaluator for SymmetricTspEvaluator {
     fn evaluate(
         &mut self,
         problem: &Self::Problem,
-        _state: &mut crate::state::State,
-        individuals: &mut [crate::framework::Individual<Self::Problem>],
+        _state: &mut State<Self::Problem>,
+        individuals: &mut [Individual<Self::Problem>],
     ) {
         for individual in individuals {
             individual.evaluate(problem.evaluate_solution(individual.solution()));

--- a/src/state/archive.rs
+++ b/src/state/archive.rs
@@ -55,16 +55,16 @@ impl<P: SingleObjectiveProblem> ElitistArchive<P> {
         where
             P: SingleObjectiveProblem,
         {
-            fn initialize(&self, _problem: &P, state: &mut State) {
-                state.insert::<ElitistArchive<P>>(ElitistArchive::new());
+            fn initialize(&self, _problem: &P, state: &mut State<P>) {
+                state.insert(ElitistArchive::<P>::new());
             }
 
-            fn execute(&self, _problem: &P, state: &mut State) {
-                let population = state.population_stack_mut().pop();
+            fn execute(&self, _problem: &P, state: &mut State<P>) {
+                let population = state.populations_mut().pop();
                 state
                     .get_mut::<ElitistArchive<P>>()
                     .state_update(&population, self.n_elitists);
-                state.population_stack_mut().push(population);
+                state.populations_mut().push(population);
             }
         }
 
@@ -80,12 +80,12 @@ impl<P: SingleObjectiveProblem> ElitistArchive<P> {
         where
             P: SingleObjectiveProblem,
         {
-            fn initialize(&self, _problem: &P, state: &mut State) {
-                state.require::<ElitistArchive<P>>();
+            fn initialize(&self, _problem: &P, state: &mut State<P>) {
+                state.require::<Self, ElitistArchive<P>>();
             }
 
-            fn execute(&self, _problem: &P, state: &mut State) {
-                let mut population = state.population_stack_mut().pop();
+            fn execute(&self, _problem: &P, state: &mut State<P>) {
+                let mut population = state.populations_mut().pop();
                 let elitism_state = state.get::<ElitistArchive<P>>();
 
                 for elitist in elitism_state.elitists() {
@@ -94,7 +94,7 @@ impl<P: SingleObjectiveProblem> ElitistArchive<P> {
                     }
                 }
 
-                state.population_stack_mut().push(population);
+                state.populations_mut().push(population);
             }
         }
 

--- a/src/state/common.rs
+++ b/src/state/common.rs
@@ -8,7 +8,7 @@ use crate::{
     problems::{MultiObjectiveProblem, SingleObjectiveProblem},
 };
 use better_any::Tid;
-use derive_deref::{Deref, DerefMut};
+use derive_more::{Deref, DerefMut};
 use serde::Serialize;
 
 /// Instance of an [Evaluator] stored in the state.
@@ -34,8 +34,8 @@ impl<'a, P: Problem> EvaluatorInstance<'a, P> {
     /// Wraps a function as an evaluator.
     ///
     /// Good for simple, stateless evaluators.
-    pub fn functional(evaluation: fn(&P, &mut State, &mut [Individual<P>])) -> Self {
-        struct FunctionalEvaluator<P: Problem>(fn(&P, &mut State, &mut [Individual<P>]));
+    pub fn functional(evaluation: fn(&P, &mut State<P>, &mut [Individual<P>])) -> Self {
+        struct FunctionalEvaluator<P: Problem>(fn(&P, &mut State<P>, &mut [Individual<P>]));
 
         impl<P: Problem> Evaluator for FunctionalEvaluator<P> {
             type Problem = P;
@@ -43,7 +43,7 @@ impl<'a, P: Problem> EvaluatorInstance<'a, P> {
             fn evaluate(
                 &mut self,
                 problem: &Self::Problem,
-                state: &mut crate::state::State,
+                state: &mut State<P>,
                 individuals: &mut [Individual<Self::Problem>],
             ) {
                 (self.0)(problem, state, individuals)
@@ -137,16 +137,13 @@ impl<P: MultiObjectiveProblem> Default for ParetoFront<P> {
     }
 }
 
-#[derive(Deref, DerefMut, Tid)]
-pub struct Loop(pub bool);
-impl CustomState<'_> for Loop {}
-
 #[derive(Default, Tid)]
-pub struct Population<P: Problem + 'static> {
+pub struct Populations<P: Problem + 'static> {
     stack: Vec<Vec<Individual<P>>>,
 }
-impl<P: Problem> CustomState<'_> for Population<P> {}
-impl<P: Problem> Population<P> {
+
+impl<P: Problem> CustomState<'_> for Populations<P> {}
+impl<P: Problem> Populations<P> {
     pub fn new() -> Self {
         Self { stack: Vec::new() }
     }

--- a/src/state/container/mod.rs
+++ b/src/state/container/mod.rs
@@ -73,17 +73,6 @@ impl<'a, P: Problem> State<'a, P> {
         self.map.insert(state);
     }
 
-    /// Changes the problem type of the state.
-    ///
-    /// Only needed for obscure use-cases when the state is reused for multiple problems.
-    pub fn transmute<O: Problem>(self: State<'a, P>) -> State<'a, O> {
-        State {
-            parent: self.parent.map(|parent| Box::new(parent.transmute::<O>())),
-            map: self.map,
-            _phantom: PhantomData::<O>,
-        }
-    }
-
     /// Tries to find an inner map containing T.
     fn find<T: CustomState<'a>>(&self) -> Option<&Self> {
         if self.map.has::<T>() {

--- a/src/state/container/mod.rs
+++ b/src/state/container/mod.rs
@@ -23,31 +23,39 @@ pub(crate) use map::StateMap;
 pub trait CustomState<'a>: Tid<'a> + Send {}
 
 /// Container for storing and managing state.
-#[derive(Default)]
-pub struct State<'a> {
-    parent: Option<Box<State<'a>>>,
+pub struct State<'a, P> {
+    parent: Option<Box<State<'a, P>>>,
     map: StateMap<'a>,
+    _phantom: std::marker::PhantomData<P>,
 }
 
-impl<'a> State<'a> {
+impl<P: Problem> Default for State<'_, P> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<'a, P: Problem> State<'a, P> {
     /// Creates a new state container.
     ///
     /// Only needed for tests.
-    pub fn new_root() -> Self {
+    pub fn new() -> Self {
         State {
             parent: None,
             map: StateMap::new(),
+            _phantom: std::marker::PhantomData,
         }
     }
 
     /// Runs a closure within a new scope.
-    pub fn with_substate(&mut self, fun: impl FnOnce(&mut State)) {
-        let mut substate: State = Self {
+    pub fn with_substate(&mut self, fun: impl FnOnce(&mut State<P>)) {
+        let mut substate: State<P> = Self {
             parent: Some(Box::new(std::mem::take(self))),
             map: StateMap::new(),
+            _phantom: std::marker::PhantomData,
         };
         fun(&mut substate);
-        *self = *substate.parent.unwrap()
+        *self = *substate.parent.unwrap();
     }
 
     /// Returns the parent state.
@@ -65,7 +73,15 @@ impl<'a> State<'a> {
         self.map.insert(state);
     }
 
-    /// Tires to find an inner map containing T.
+    pub fn transmute<O: Problem>(self: State<'a, P>) -> State<'a, O> {
+        State {
+            parent: self.parent.map(|parent| Box::new(parent.transmute::<O>())),
+            map: self.map,
+            _phantom: std::marker::PhantomData::<O>,
+        }
+    }
+
+    /// Tries to find an inner map containing T.
     fn find<T: CustomState<'a>>(&self) -> Option<&Self> {
         if self.map.has::<T>() {
             Some(self)
@@ -93,10 +109,11 @@ impl<'a> State<'a> {
     /// This is the recommended way to ensure the state
     /// is available in [Component::initialize](crate::framework::components::Component::initialize).
     #[track_caller]
-    pub fn require<T: CustomState<'a>>(&self) {
+    pub fn require<C, T: CustomState<'a>>(&self) {
         assert!(
             self.has::<T>(),
-            "operator requires {} state",
+            "{} requires {} state",
+            std::any::type_name::<C>(),
             std::any::type_name::<T>()
         );
     }
@@ -178,7 +195,7 @@ impl<'a> State<'a> {
     /// ```
     /// use mahf::{state::{State, common::Population}, framework::Random, problems::bmf::BenchmarkFunction};
     /// let problem = BenchmarkFunction::sphere(3);
-    /// let mut state = State::new_root();
+    /// let mut state = State::new();
     /// state.insert(Random::testing());
     /// state.insert(Population::<BenchmarkFunction>::new());
     ///
@@ -188,7 +205,7 @@ impl<'a> State<'a> {
     ///
     /// // Do something with rng and population, or borrow additional types.
     /// ```
-    pub fn get_states_mut<'b>(&'b mut self) -> MutState<'b, 'a> {
+    pub fn get_states_mut<'b>(&'b mut self) -> MutState<'b, 'a, P> {
         MutState::new(self)
     }
 
@@ -236,7 +253,7 @@ impl<'a> State<'a> {
     /// ```
     /// use mahf::{state::{State, common::Population}, framework::Random, problems::bmf::BenchmarkFunction};
     /// let problem = BenchmarkFunction::sphere(3);
-    /// let mut state = State::new_root();
+    /// let mut state = State::new();
     /// state.insert(Random::testing());
     /// state.insert(Population::<BenchmarkFunction>::new());
     ///
@@ -250,70 +267,107 @@ impl<'a> State<'a> {
     }
 }
 
-/// Convenience functions for often required state.
-///
-/// If some state does not exist, the function will panic.
-macro_rules! impl_convenience_functions {
-    ($l:lifetime, $t:ty) => {
+macro_rules! impl_convenience_methods {
+    ($lifetime:lifetime, $self_type:ty) => {
         /// Returns [Iterations](common::Iterations) state.
-        pub fn iterations(self: $t) -> u32 {
+        pub fn iterations(self: $self_type) -> u32 {
             self.get_value::<common::Iterations>()
         }
 
         /// Returns [Evaluations](common::Evaluations) state.
-        pub fn evaluations(self: $t) -> u32 {
+        pub fn evaluations(self: $self_type) -> u32 {
             self.get_value::<common::Evaluations>()
         }
 
-        /// Returns [BestIndividual](common::BestIndividual) state.
-        pub fn best_individual<P: SingleObjectiveProblem>(self: $t) -> Option<&$l Individual<P>> {
-            self.get::<common::BestIndividual<P>>().as_ref()
+        /// Returns [Population](common::Populations) state.
+        pub fn populations(self: $self_type) -> &$lifetime common::Populations<P> {
+            self.get::<common::Populations<P>>()
         }
 
-        /// Returns the objective value of the [BestIndividual](common::BestIndividual).
-        pub fn best_objective_value<P: SingleObjectiveProblem>(
-            self: $t,
-        ) -> Option<&SingleObjective> {
-            self.best_individual::<P>().map(|i| i.objective())
-        }
-
-        /// Returns [ParetoFront](common::ParetoFront) state.
-        pub fn pareto_front<P: MultiObjectiveProblem>(self: $t) -> &$l common::ParetoFront<P> {
-            self.get::<common::ParetoFront<P>>()
-        }
-
-        /// Returns [Population](common::Population) state.
-        pub fn population_stack<P: Problem>(self: $t) -> &$l common::Population<P> {
-            self.get::<common::Population<P>>()
-        }
-
-        /// Returns mutable [Population](common::Population) state.
-        pub fn population_stack_mut<P: Problem>(&mut self) -> &$l mut common::Population<P> {
-            self.get_mut::<common::Population<P>>()
+        /// Returns mutable [Population](common::Populations) state.
+        pub fn populations_mut(&mut self) -> &$lifetime mut common::Populations<P> {
+            self.get_mut::<common::Populations<P>>()
         }
 
         /// Returns mutable [Random](random::Random) state.
-        pub fn random_mut(&mut self) -> &$l mut Random {
+        pub fn random_mut(&mut self) -> &$lifetime mut Random {
             self.get_mut::<Random>()
         }
 
         /// Returns the [Log].
-        pub fn log(self: $t) -> &$l Log {
+        pub fn log(self: $self_type) -> &$lifetime Log {
             self.get::<Log>()
         }
     };
 }
 
-impl<'a> State<'a> {
+impl<'a, P: Problem> State<'a, P> {
     // Uses '_ as 'self lifetime.
     // This has to match the lifetime bounds of [State::get].
-    impl_convenience_functions!('_, &Self);
+    impl_convenience_methods!('_, &Self);
 }
 
-impl<'a, 's> MutState<'a, 's> {
+impl<'a, 's, P: Problem> MutState<'a, 's, P> {
     // Uses 'a as the internal [State]s lifetime.
     // This has to match the lifetime bounds of [MutState::get].
-    impl_convenience_functions!('a, &mut Self);
+    impl_convenience_methods!('a, &mut Self);
+}
+
+macro_rules! impl_single_objective_convenience_methods {
+    ($lifetime:lifetime, $self_type:ty) => {
+        /// Returns [BestIndividual](common::BestIndividual) state.
+        pub fn best_individual(self: $self_type) -> Option<&$lifetime Individual<P>> {
+            self.get::<common::BestIndividual<P>>().as_ref()
+        }
+
+        /// Returns [BestIndividual](common::BestIndividual) state.
+        pub fn best_individual_mut(&mut self) -> Option<&$lifetime mut Individual<P>> {
+            self.get_mut::<common::BestIndividual<P>>().as_mut()
+        }
+
+        /// Returns the objective value of the [BestIndividual](common::BestIndividual).
+        pub fn best_objective_value(self: $self_type) -> Option<&$lifetime SingleObjective> {
+            self.best_individual().map(|i| i.objective())
+        }
+    };
+}
+
+impl<'a, P: SingleObjectiveProblem> State<'a, P> {
+    // Uses '_ as 'self lifetime.
+    // This has to match the lifetime bounds of [State::get].
+    impl_single_objective_convenience_methods!('_, &Self);
+}
+
+impl<'a, 's, P: SingleObjectiveProblem> MutState<'a, 's, P> {
+    // Uses 'a as the internal [State]s lifetime.
+    // This has to match the lifetime bounds of [MutState::get].
+    impl_single_objective_convenience_methods!('a, &mut Self);
+}
+
+macro_rules! impl_multi_objective_convenience_methods {
+    ($lifetime:lifetime, $self_type:ty) => {
+        /// Returns [ParetoFront](common::ParetoFront) state.
+        pub fn pareto_front(self: $self_type) -> &$lifetime common::ParetoFront<P> {
+            self.get::<common::ParetoFront<P>>()
+        }
+
+        /// Returns [ParetoFront](common::ParetoFront) state.
+        pub fn pareto_front_mut(&mut self) -> &$lifetime mut common::ParetoFront<P> {
+            self.get_mut::<common::ParetoFront<P>>()
+        }
+    };
+}
+
+impl<'a, P: MultiObjectiveProblem> State<'a, P> {
+    // Uses '_ as 'self lifetime.
+    // This has to match the lifetime bounds of [State::get].
+    impl_multi_objective_convenience_methods!('_, &Self);
+}
+
+impl<'a, 's, P: MultiObjectiveProblem> MutState<'a, 's, P> {
+    // Uses 'a as the internal [State]s lifetime.
+    // This has to match the lifetime bounds of [MutState::get].
+    impl_multi_objective_convenience_methods!('a, &mut Self);
 }
 
 #[derive(Tid)]

--- a/src/state/cro.rs
+++ b/src/state/cro.rs
@@ -57,7 +57,7 @@ impl<P> Component<P> for CroStateInitialization
 where
     P: SingleObjectiveProblem,
 {
-    fn initialize(&self, _problem: &P, state: &mut State) {
+    fn initialize(&self, _problem: &P, state: &mut State<P>) {
         // Initialize with empty state to satisfy `state.require()` statements
         state.insert(CroState::<P> {
             buffer: 0.,
@@ -65,8 +65,8 @@ where
         })
     }
 
-    fn execute(&self, _problem: &P, state: &mut State) {
-        let population = state.population_stack::<P>().current();
+    fn execute(&self, _problem: &P, state: &mut State<P>) {
+        let population = state.populations().current();
         let molecules = population
             .iter()
             .map(|i| Molecule::new(self.initial_kinetic_energy, i))
@@ -88,21 +88,25 @@ impl<P> Component<P> for OnWallIneffectiveCollisionUpdate
 where
     P: SingleObjectiveProblem,
 {
-    fn initialize(&self, _problem: &P, state: &mut State) {
-        state.require::<CroState<P>>();
+    fn initialize(&self, _problem: &P, state: &mut State<P>) {
+        state.require::<Self, CroState<P>>();
     }
 
-    fn execute(&self, _problem: &P, state: &mut State) {
+    fn execute(&self, _problem: &P, state: &mut State<P>) {
         let mut mut_state = state.get_states_mut();
-        let stack = mut_state.population_stack_mut::<P>();
+        let populations = mut_state.populations_mut();
         let mut cro_state = mut_state.get_mut::<CroState<P>>();
         let rng = mut_state.random_mut();
 
         // Get reaction reactant and product
-        let product = stack.pop().into_iter().next().unwrap();
-        let reactant = stack.pop().into_iter().next().unwrap();
+        let product = populations.pop().into_iter().next().unwrap();
+        let reactant = populations.pop().into_iter().next().unwrap();
 
-        let reactant_index = stack.current().iter().position(|i| i == &reactant).unwrap();
+        let reactant_index = populations
+            .current()
+            .iter()
+            .position(|i| i == &reactant)
+            .unwrap();
 
         cro_state.molecules[reactant_index].num_hit += 1;
 
@@ -123,7 +127,7 @@ where
             // Replace individual
             cro_state.molecules[reactant_index].kinetic_energy =
                 (total_reactant_energy - product_energy) * alpha;
-            stack.current_mut()[reactant_index] = product;
+            populations.current_mut()[reactant_index] = product;
         }
     }
 }
@@ -135,21 +139,25 @@ impl<P> Component<P> for DecompositionUpdate
 where
     P: SingleObjectiveProblem,
 {
-    fn initialize(&self, _problem: &P, state: &mut State) {
-        state.require::<CroState<P>>();
+    fn initialize(&self, _problem: &P, state: &mut State<P>) {
+        state.require::<Self, CroState<P>>();
     }
 
-    fn execute(&self, _problem: &P, state: &mut State) {
+    fn execute(&self, _problem: &P, state: &mut State<P>) {
         let mut mut_state = state.get_states_mut();
-        let stack = mut_state.population_stack_mut::<P>();
+        let populations = mut_state.populations_mut();
         let mut cro_state = mut_state.get_mut::<CroState<P>>();
         let rng = mut_state.random_mut();
 
         // Get reaction reactant and products p1, p2
-        let [p1, p2] = TryInto::<[_; 2]>::try_into(stack.pop()).ok().unwrap();
-        let reactant = stack.pop().into_iter().next().unwrap();
+        let [p1, p2] = TryInto::<[_; 2]>::try_into(populations.pop()).ok().unwrap();
+        let reactant = populations.pop().into_iter().next().unwrap();
 
-        let reactant_index = stack.current().iter().position(|i| i == &reactant).unwrap();
+        let reactant_index = populations
+            .current()
+            .iter()
+            .position(|i| i == &reactant)
+            .unwrap();
 
         let total_reactant_energy =
             reactant.objective().value() + cro_state.molecules[reactant_index].kinetic_energy;
@@ -183,7 +191,7 @@ where
             .molecules
             .push(Molecule::new(decomposition_energy * (1. - d3), &p2));
 
-        let population = stack.current_mut();
+        let population = populations.current_mut();
         population[reactant_index] = p1;
         population.push(p2);
     }
@@ -196,22 +204,22 @@ impl<P> Component<P> for IntermolecularIneffectiveCollisionUpdate
 where
     P: SingleObjectiveProblem,
 {
-    fn initialize(&self, _problem: &P, state: &mut State) {
-        state.require::<CroState<P>>();
+    fn initialize(&self, _problem: &P, state: &mut State<P>) {
+        state.require::<Self, CroState<P>>();
     }
 
-    fn execute(&self, _problem: &P, state: &mut State) {
+    fn execute(&self, _problem: &P, state: &mut State<P>) {
         let mut mut_state = state.get_states_mut();
-        let stack: &mut crate::state::common::Population<P> = mut_state.population_stack_mut::<P>();
+        let populations = mut_state.populations_mut();
         let cro_state = mut_state.get_mut::<CroState<P>>();
         let rng = mut_state.random_mut();
 
         // Get reaction reactants r1, r2 and products p1, p2
-        let [p1, p2] = TryInto::<[_; 2]>::try_into(stack.pop()).ok().unwrap();
-        let [r1, r2] = TryInto::<[_; 2]>::try_into(stack.pop()).ok().unwrap();
+        let [p1, p2] = TryInto::<[_; 2]>::try_into(populations.pop()).ok().unwrap();
+        let [r1, r2] = TryInto::<[_; 2]>::try_into(populations.pop()).ok().unwrap();
 
-        let r1_index = stack.current().iter().position(|i| i == &r1).unwrap();
-        let r2_index = stack.current().iter().position(|i| i == &r2).unwrap();
+        let r1_index = populations.current().iter().position(|i| i == &r1).unwrap();
+        let r2_index = populations.current().iter().position(|i| i == &r2).unwrap();
 
         if r1_index == r2_index {
             panic!("Molecule can't collide with itself.");
@@ -243,7 +251,7 @@ where
             cro_state.molecules[r2_index].update_best(&p2);
 
             // Replace individual
-            let population = stack.current_mut();
+            let population = populations.current_mut();
             population[r1_index] = p1;
             population[r2_index] = p2;
         }
@@ -257,21 +265,21 @@ impl<P> Component<P> for SynthesisUpdate
 where
     P: SingleObjectiveProblem,
 {
-    fn initialize(&self, _problem: &P, state: &mut State) {
-        state.require::<CroState<P>>();
+    fn initialize(&self, _problem: &P, state: &mut State<P>) {
+        state.require::<Self, CroState<P>>();
     }
 
-    fn execute(&self, _problem: &P, state: &mut State) {
+    fn execute(&self, _problem: &P, state: &mut State<P>) {
         let mut mut_state = state.get_states_mut();
-        let stack: &mut crate::state::common::Population<P> = mut_state.population_stack_mut::<P>();
+        let populations = mut_state.populations_mut();
         let cro_state = mut_state.get_mut::<CroState<P>>();
 
         // Get reaction reactants r1, r2 and product
-        let product = stack.pop().into_iter().next().unwrap();
-        let [r1, r2] = TryInto::<[_; 2]>::try_into(stack.pop()).ok().unwrap();
+        let product = populations.pop().into_iter().next().unwrap();
+        let [r1, r2] = TryInto::<[_; 2]>::try_into(populations.pop()).ok().unwrap();
 
-        let r1_index = stack.current().iter().position(|i| i == &r1).unwrap();
-        let r2_index = stack.current().iter().position(|i| i == &r2).unwrap();
+        let r1_index = populations.current().iter().position(|i| i == &r1).unwrap();
+        let r2_index = populations.current().iter().position(|i| i == &r2).unwrap();
 
         if r1_index == r2_index {
             panic!("Molecule can't collide with itself.");
@@ -291,7 +299,7 @@ where
             cro_state.molecules.remove(r2_index);
 
             // Replace one individual and remove other
-            let population = stack.current_mut();
+            let population = populations.current_mut();
             population[r1_index] = product;
             population.remove(r2_index);
         }

--- a/src/state/diversity.rs
+++ b/src/state/diversity.rs
@@ -8,7 +8,7 @@ use serde::Serialize;
 use crate::{
     framework::components::*,
     problems::{Problem, VectorProblem},
-    state::{common::Population, CustomState, State},
+    state::{common::Populations, CustomState, State},
 };
 
 /// Specialized component trait to measure population diversity.
@@ -28,15 +28,15 @@ where
     P: Problem,
     I: AnyComponent + DiversityMeasure<P> + Serialize + Clone,
 {
-    fn initialize(&self, _problem: &P, state: &mut State) {
+    fn initialize(&self, _problem: &P, state: &mut State<P>) {
         state.insert(DiversityState::<I>::default());
     }
 
-    fn execute(&self, problem: &P, state: &mut State) {
-        let (population_stack, diversity_state) =
-            state.get_multiple_mut::<(Population<P>, DiversityState<I>)>();
+    fn execute(&self, problem: &P, state: &mut State<P>) {
+        let (populations, diversity_state) =
+            state.get_multiple_mut::<(Populations<P>, DiversityState<I>)>();
 
-        let population = population_stack.current();
+        let population = populations.current();
 
         if population.is_empty() {
             diversity_state.diversity = 0.0;
@@ -73,7 +73,6 @@ impl<P: Problem<Encoding = Vec<f64>> + VectorProblem<T = f64>> DiversityMeasure<
         let d = problem.dimension();
 
         (0..d)
-            .into_iter()
             .map(|k| {
                 let xk = solutions.iter().map(|s| s[k]).sum::<f64>() / n;
                 solutions.iter().map(|s| (s[k] - xk).abs()).sum::<f64>() / n
@@ -132,7 +131,6 @@ impl<P: Problem<Encoding = Vec<f64>> + VectorProblem<T = f64>> DiversityMeasure<
         let d = problem.dimension();
 
         (0..d)
-            .into_iter()
             .map(|k| {
                 let xk = solutions.iter().map(|s| s[k]).sum::<f64>() / n;
                 let sum = solutions.iter().map(|i| i[k].powi(2)).sum::<f64>() / n;

--- a/src/state/pso.rs
+++ b/src/state/pso.rs
@@ -35,7 +35,7 @@ where
         where
             P: SingleObjectiveProblem<Encoding = Vec<f64>> + LimitedVectorProblem<T = f64>,
         {
-            fn initialize(&self, _problem: &P, state: &mut State) {
+            fn initialize(&self, _problem: &P, state: &mut State<P>) {
                 // Initialize with empty state to satisfy `state.require()` statements
                 state.insert(PsoState {
                     velocities: vec![],
@@ -44,19 +44,17 @@ where
                 })
             }
 
-            fn execute(&self, problem: &P, state: &mut State) {
-                let population = state.population_stack_mut::<P>().pop();
+            fn execute(&self, problem: &P, state: &mut State<P>) {
+                let population = state.populations_mut().pop();
                 let rng = state.random_mut();
 
-                let velocities = population
-                    .iter()
-                    .map(|_| {
-                        (0..problem.dimension())
-                            .into_iter()
-                            .map(|_| rng.gen_range(-self.v_max..=self.v_max))
-                            .collect::<Vec<f64>>()
-                    })
-                    .collect::<Vec<Vec<f64>>>();
+                let velocities = std::iter::repeat_with(|| {
+                    std::iter::repeat_with(|| rng.gen_range(-self.v_max..=self.v_max))
+                        .take(problem.dimension())
+                        .collect::<Vec<_>>()
+                })
+                .take(population.len())
+                .collect::<Vec<_>>();
 
                 let bests = population.to_vec();
 
@@ -66,7 +64,7 @@ where
                     .cloned()
                     .unwrap();
 
-                state.population_stack_mut().push(population);
+                state.populations_mut().push(population);
 
                 state.insert(PsoState {
                     velocities,
@@ -90,25 +88,28 @@ where
         where
             P: Problem<Encoding = Vec<f64>> + LimitedVectorProblem<T = f64>,
         {
-            fn initialize(&self, _problem: &P, state: &mut State) {
-                state.require::<PsoState<P>>();
+            fn initialize(&self, _problem: &P, state: &mut State<P>) {
+                state.require::<Self, PsoState<P>>();
             }
 
-            fn execute(&self, _problem: &P, state: &mut State) {
-                let population = state.population_stack_mut().pop();
-                let mut pso_state = state.get_mut::<PsoState<P>>();
+            fn execute(&self, _problem: &P, state: &mut State<P>) {
+                let population = state.populations_mut().pop();
 
-                for (i, individual) in population.iter().enumerate() {
-                    if pso_state.bests[i].objective() > individual.objective() {
-                        pso_state.bests[i] = individual.clone();
+                let PsoState {
+                    bests, global_best, ..
+                } = &mut state.get_mut::<PsoState<P>>();
 
-                        if pso_state.global_best.objective() > individual.objective() {
-                            pso_state.global_best = individual.clone();
+                for (individual, best) in population.iter().zip(bests.iter_mut()) {
+                    if best.objective() > individual.objective() {
+                        *best = individual.clone();
+
+                        if global_best.objective() > individual.objective() {
+                            *global_best = individual.clone();
                         }
                     }
                 }
 
-                state.population_stack_mut().push(population);
+                state.populations_mut().push(population);
             }
         }
 

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -3,7 +3,7 @@
 use crate::{
     framework::{Individual, SingleObjective},
     problems::{Evaluator, HasKnownOptimum, Problem, SingleObjectiveProblem},
-    state::common::EvaluatorInstance,
+    state::{common::EvaluatorInstance, State},
 };
 use std::borrow::Borrow;
 
@@ -37,7 +37,7 @@ impl Evaluator for TestEvaluator {
     fn evaluate(
         &mut self,
         _problem: &Self::Problem,
-        _state: &mut crate::state::State,
+        _state: &mut State<Self::Problem>,
         individuals: &mut [Individual<Self::Problem>],
     ) {
         for individual in individuals {

--- a/src/tracking/log.rs
+++ b/src/tracking/log.rs
@@ -1,4 +1,7 @@
-use crate::state::{common, CustomState, State};
+use crate::{
+    problems::Problem,
+    state::{common, CustomState, State},
+};
 use better_any::Tid;
 use erased_serde::Serialize as DynSerialize;
 use serde::Serialize;
@@ -58,7 +61,7 @@ impl Step {
     /// Pushes the current iteration if it has not been logged yet.
     ///
     /// Will also ensure that the iteration is at index 0.
-    pub(crate) fn push_iteration(&mut self, state: &State) {
+    pub(crate) fn push_iteration<P: Problem>(&mut self, state: &State<P>) {
         let name = type_name::<common::Iterations>();
 
         if !self.contains(name) {

--- a/src/tracking/logger.rs
+++ b/src/tracking/logger.rs
@@ -28,7 +28,7 @@ impl Logger {
 }
 
 impl<P: Problem> Component<P> for Logger {
-    fn initialize(&self, problem: &P, state: &mut State) {
+    fn initialize(&self, problem: &P, state: &mut State<P>) {
         if state.has::<LogSet<P>>() {
             state.holding::<LogSet<P>>(|sets, state| {
                 for (trigger, _) in &sets.entries {
@@ -38,7 +38,7 @@ impl<P: Problem> Component<P> for Logger {
         }
     }
 
-    fn execute(&self, problem: &P, state: &mut State) {
+    fn execute(&self, problem: &P, state: &mut State<P>) {
         if state.has::<LogSet<P>>() {
             state.holding::<LogSet<P>>(|sets, state| {
                 let mut step = Step::default();

--- a/src/tracking/set.rs
+++ b/src/tracking/set.rs
@@ -38,7 +38,11 @@ impl<'a, P: Problem + 'static> LogSet<'a, P> {
         }
     }
 
-    pub fn with(mut self, trigger: Box<dyn Trigger<'a, P> + 'a>, extractor: Extractor<'a, P>) -> Self {
+    pub fn with(
+        mut self,
+        trigger: Box<dyn Trigger<'a, P> + 'a>,
+        extractor: Extractor<'a, P>,
+    ) -> Self {
         self.entries.push((trigger, extractor));
         self
     }

--- a/src/tracking/set.rs
+++ b/src/tracking/set.rs
@@ -13,7 +13,7 @@ use serde::Serialize;
 /// A combination of [Trigger] and [LogFn].
 #[derive(Default, Tid)]
 pub struct LogSet<'a, P: 'static> {
-    pub(crate) entries: Vec<(Box<dyn Trigger<'a, P> + 'a>, Extractor<'a>)>,
+    pub(crate) entries: Vec<(Box<dyn Trigger<'a, P> + 'a>, Extractor<'a, P>)>,
 }
 
 impl<'a, P> Clone for LogSet<'a, P> {
@@ -38,7 +38,7 @@ impl<'a, P: Problem + 'static> LogSet<'a, P> {
         }
     }
 
-    pub fn with(mut self, trigger: Box<dyn Trigger<'a, P> + 'a>, extractor: Extractor<'a>) -> Self {
+    pub fn with(mut self, trigger: Box<dyn Trigger<'a, P> + 'a>, extractor: Extractor<'a, P>) -> Self {
         self.entries.push((trigger, extractor));
         self
     }
@@ -47,7 +47,7 @@ impl<'a, P: Problem + 'static> LogSet<'a, P> {
     where
         T: CustomState<'a> + Clone + Serialize + 'static,
     {
-        self.entries.push((trigger, functions::auto::<T>));
+        self.entries.push((trigger, functions::auto::<T, P>));
         self
     }
 
@@ -55,11 +55,11 @@ impl<'a, P: Problem + 'static> LogSet<'a, P> {
     ///
     /// Every 10 [Iteration][common::Iterations], [common::Evaluations] and [common::Progress] are logged.
     pub fn with_common_extractors(self, trigger: Box<dyn Trigger<'a, P> + 'a>) -> Self {
-        self.with(trigger.clone(), functions::auto::<common::Evaluations>)
-            .with(trigger.clone(), functions::auto::<common::Progress>)
+        self.with(trigger.clone(), functions::auto::<common::Evaluations, _>)
+            .with(trigger.clone(), functions::auto::<common::Progress, _>)
     }
 
-    pub(crate) fn execute(&self, problem: &P, state: &mut State<'a>, step: &mut Step) {
+    pub(crate) fn execute(&self, problem: &P, state: &mut State<'a, P>, step: &mut Step) {
         for (trigger, extractor) in &self.entries {
             if trigger.evaluate(problem, state) {
                 step.push((extractor)(state));


### PR DESCRIPTION
- Rename `Population` to `Populations`.
- Rename some convenience methods of `State`, most notably `population_stack` to `populations`.
- Make `State` generic over the problem type, so `best_individual` and such don't need a type annotation.

These were some changes that I think are more elegant that came up when writing the Tech Report. Making `State` generic might sound unintuitive because it doesn't actually depend on `P` aside from the convenience methods, but I think those are important enough that omitting the type parameter there is more intuitive. It also integrated quite nicely with logging, so there's that. When writing the Python wrapper, I actually needed to wrap `State` into a wrapper that is generic over `P` anyway, so that was a first indicator that this might be more elegant.

