### PR TITLE
Cleanup logging

### DIFF
--- a/src/tracking/files.rs
+++ b/src/tracking/files.rs
@@ -14,7 +14,7 @@ use crate::tracking::Log;
 #[derive(Default, Serialize)]
 struct CompressedLog<'a> {
     names: Vec<&'static str>,
-    entries: Vec<Vec<CompressedEntry<'a>>>,
+    entries: Vec<HashMap<usize, &'a dyn DynSerialize>>,
 }
 
 #[derive(Serialize)]
@@ -31,7 +31,8 @@ impl<'a> From<&'a Log> for CompressedLog<'a> {
         let mut keys: HashMap<&'static str, usize> = HashMap::new();
 
         for step in log.steps() {
-            let mut cstep = Vec::with_capacity(step.entries().len());
+            let mut cstep: HashMap<usize, &'a dyn DynSerialize> =
+                HashMap::with_capacity(step.entries().len());
 
             for entry in step.entries() {
                 let key = *keys.entry(entry.name).or_insert_with(|| {
@@ -42,7 +43,7 @@ impl<'a> From<&'a Log> for CompressedLog<'a> {
                 });
                 let value = &entry.value;
 
-                cstep.push(CompressedEntry { key, value });
+                cstep.insert(key, value);
             }
 
             clog.entries.push(cstep);

--- a/src/tracking/files.rs
+++ b/src/tracking/files.rs
@@ -17,12 +17,6 @@ struct CompressedLog<'a> {
     entries: Vec<HashMap<usize, &'a dyn DynSerialize>>,
 }
 
-#[derive(Serialize)]
-struct CompressedEntry<'a> {
-    key: usize,
-    value: &'a dyn DynSerialize,
-}
-
 impl<'a> From<&'a Log> for CompressedLog<'a> {
     fn from(log: &'a Log) -> Self {
         let mut clog = CompressedLog::default();
@@ -31,8 +25,7 @@ impl<'a> From<&'a Log> for CompressedLog<'a> {
         let mut keys: HashMap<&'static str, usize> = HashMap::new();
 
         for step in log.steps() {
-            let mut cstep: HashMap<usize, &'a dyn DynSerialize> =
-                HashMap::with_capacity(step.entries().len());
+            let mut cstep = HashMap::with_capacity(step.entries().len());
 
             for entry in step.entries() {
                 let key = *keys.entry(entry.name).or_insert_with(|| {
@@ -41,7 +34,8 @@ impl<'a> From<&'a Log> for CompressedLog<'a> {
                     next_key += 1;
                     key
                 });
-                let value = &entry.value;
+
+                let value: &'a dyn DynSerialize = &entry.value;
 
                 cstep.insert(key, value);
             }

--- a/src/tracking/functions.rs
+++ b/src/tracking/functions.rs
@@ -7,7 +7,7 @@ use serde::Serialize;
 use std::{any::type_name, ops::Deref};
 
 /// A function to turn some state into an [Entry].
-pub type LogFn<'a> = fn(&State<'a>) -> Entry;
+pub type Extractor<'a> = fn(&State<'a>) -> Entry;
 
 /// A function to log anything that implements [Clone] + [Serialize]
 pub fn auto<'a, T>(state: &State<'a>) -> Entry

--- a/src/tracking/set.rs
+++ b/src/tracking/set.rs
@@ -2,7 +2,7 @@ use crate::{
     problems::Problem,
     state::{common, CustomState, State},
     tracking::{
-        functions::{self, LogFn},
+        functions::{self, Extractor},
         log::Step,
         trigger::Trigger,
     },
@@ -13,7 +13,7 @@ use serde::Serialize;
 /// A combination of [Trigger] and [LogFn].
 #[derive(Default, Tid)]
 pub struct LogSet<'a, P: 'static> {
-    pub(crate) entries: Vec<(Box<dyn Trigger<'a, P> + 'a>, LogFn<'a>)>,
+    pub(crate) entries: Vec<(Box<dyn Trigger<'a, P> + 'a>, Extractor<'a>)>,
 }
 
 impl<'a, P> Clone for LogSet<'a, P> {
@@ -38,7 +38,7 @@ impl<'a, P: Problem + 'static> LogSet<'a, P> {
         }
     }
 
-    pub fn with(mut self, trigger: Box<dyn Trigger<'a, P> + 'a>, extractor: LogFn<'a>) -> Self {
+    pub fn with(mut self, trigger: Box<dyn Trigger<'a, P> + 'a>, extractor: Extractor<'a>) -> Self {
         self.entries.push((trigger, extractor));
         self
     }


### PR DESCRIPTION
- `LogFn` is now called `Extractor`
- Logs are stored as maps

The latter reduces the average log size from ~18 KB to ~8 KB.