### PR TITLE
Fix license warning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,6 @@ name = "mahf"
 version = "0.1.0"
 description = "A framework for modular construction and evaluation of metaheuristics."
 license = "GPL-3.0-or-later"
-license-file = "LICENSE"
 repository = "https://github.com/mahf-opt/mahf"
 keywords = ["heuristic", "metaheuristic", "optimization"]
 categories = ["science", "algorithms"]


### PR DESCRIPTION
Fixes ```warning: only one of `license` or `license-file` is necessary``` by removing `license-file` key from `cargo.toml`.