### PR TITLE
Add hybrid examples and some refactors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ derivative = "2.2.0"
 itertools = "0.10.5"
 better_any = { version = "0.2.0", features = ["derive"] }
 scoped_threadpool = "0.1.9"
+contracts = "0.6.3"
 
 [patch.crates-io]
 better_typeid_derive = { git = "https://github.com/luleyleo/better_any", branch = "no-use-tidable", package = "better_typeid_derive" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ itertools = "0.10.5"
 better_any = { version = "0.2.0", features = ["derive"] }
 scoped_threadpool = "0.1.9"
 contracts = "0.6.3"
+rayon = "1.7.0"
 
 [patch.crates-io]
 better_typeid_derive = { git = "https://github.com/luleyleo/better_any", branch = "no-use-tidable", package = "better_typeid_derive" }

--- a/examples/bmf.rs
+++ b/examples/bmf.rs
@@ -11,13 +11,13 @@ fn main() {
             num_particles: 20,
             start_weight: 0.9,
             end_weight: 0.4,
-            c_one: 1.0,
-            c_two: 1.0,
+            c_one: 1.7,
+            c_two: 1.7,
             v_max: 1.0,
         },
         /*termination: */
         termination::LessThanN::<state::common::Iterations>::new(/*n: */ 500)
-            & termination::DistanceToOpt::new(0.01),
+            & termination::DistanceToOptGreaterThan::new(0.01),
     );
 
     // Execute the metaheuristic on the problem with a random seed.

--- a/examples/bmf.rs
+++ b/examples/bmf.rs
@@ -16,7 +16,7 @@ fn main() {
             v_max: 1.0,
         },
         /*termination: */
-        termination::FixedIterations::new(/*max_iterations: */ 500)
+        termination::LessThanN::<state::common::Iterations>::new(/*n: */ 500)
             & termination::DistanceToOpt::new(0.01),
     );
 
@@ -27,5 +27,14 @@ fn main() {
     println!("Found Individual: {:?}", state.best_individual().unwrap());
     println!("This took {} iterations.", state.iterations());
     println!("Global Optimum: {}", problem.known_optimum());
-    println!("Population fitness mean: {:?}", state.populations().current().iter().map(|i| i.objective().value()).sum::<f64>() / 20.)
+    println!(
+        "Population fitness mean: {:?}",
+        state
+            .populations()
+            .current()
+            .iter()
+            .map(|i| i.objective().value())
+            .sum::<f64>()
+            / 20.
+    )
 }

--- a/examples/bmf.rs
+++ b/examples/bmf.rs
@@ -3,13 +3,14 @@ use problems::bmf::BenchmarkFunction;
 
 fn main() {
     // Specify the problem: Sphere function with 10 dimensions.
-    let problem: BenchmarkFunction = BenchmarkFunction::sphere(/*dim: */ 10);
+    let problem: BenchmarkFunction = BenchmarkFunction::rastrigin(/*dim: */ 10);
     // Specify the metaheuristic: Particle Swarm Optimization (pre-implemented in MAHF).
     let config: Configuration<BenchmarkFunction> = pso::real_pso(
         /*params: */
         pso::RealProblemParameters {
             num_particles: 20,
-            weight: 1.0,
+            start_weight: 0.9,
+            end_weight: 0.4,
             c_one: 1.0,
             c_two: 1.0,
             v_max: 1.0,
@@ -26,4 +27,5 @@ fn main() {
     println!("Found Individual: {:?}", state.best_individual().unwrap());
     println!("This took {} iterations.", state.iterations());
     println!("Global Optimum: {}", problem.known_optimum());
+    println!("Population fitness mean: {:?}", state.populations().current().iter().map(|i| i.objective().value()).sum::<f64>() / 20.)
 }

--- a/examples/bmf_depso.rs
+++ b/examples/bmf_depso.rs
@@ -5,9 +5,8 @@ fn main() {
     let y = 2;
     let f = 1.;
 
-    // Specify the problem: Sphere function with 10 dimensions.
     let problem: BenchmarkFunction = BenchmarkFunction::rastrigin(/*dim: */ 30);
-    // Specify the metaheuristic: Particle Swarm Optimization (pre-implemented in MAHF).
+
     let config: Configuration<BenchmarkFunction> = Configuration::builder()
         .do_(initialization::RandomSpread::new_init(4 * 30))
         .evaluate()
@@ -15,7 +14,7 @@ fn main() {
         .do_(state::ParticleSwarm::initializer(1.))
         .while_(
             termination::LessThanN::<state::common::Iterations>::new(/*n: */ 500)
-                & termination::DistanceToOpt::new(0.01),
+                & termination::DistanceToOptGreaterThan::new(0.01),
             |builder| {
                 builder
                     .if_else_(

--- a/examples/bmf_depso.rs
+++ b/examples/bmf_depso.rs
@@ -1,0 +1,51 @@
+use mahf::prelude::*;
+use problems::bmf::BenchmarkFunction;
+
+fn main() {
+    let y = 2;
+    let f = 1.;
+
+    // Specify the problem: Sphere function with 10 dimensions.
+    let problem: BenchmarkFunction = BenchmarkFunction::rastrigin(/*dim: */ 30);
+    // Specify the metaheuristic: Particle Swarm Optimization (pre-implemented in MAHF).
+    let config: Configuration<BenchmarkFunction> = Configuration::builder()
+        .do_(initialization::RandomSpread::new_init(4 * 30))
+        .evaluate()
+        .update_best_individual()
+        .do_(state::ParticleSwarm::initializer(1.))
+        .while_(
+            termination::LessThanN::<state::common::Iterations>::new(/*n: */ 500)
+                & termination::DistanceToOpt::new(0.01),
+            |builder| {
+                builder
+                    .if_else_(
+                        branching::RandomChance::new(0.8),
+                        |builder| {
+                            builder
+                                .do_(selection::DEBest::new(y))
+                                .do_(generation::mutation::DEMutation::new(y, f))
+                                .do_(generation::recombination::DEBinomialCrossover::new(0.8))
+                        },
+                        |builder| {
+                            builder.do_(selection::All::new()).do_(
+                                generation::swarm::ParticleSwarmGeneration::new(1., 1., 1., 1.),
+                            )
+                        },
+                    )
+                    .do_(constraints::Saturation::new())
+                    .evaluate()
+                    .update_best_individual()
+                    .do_(replacement::KeepBetterAtIndex::new())
+                    .do_(state::ParticleSwarm::updater())
+            },
+        )
+        .build();
+
+    // Execute the metaheuristic on the problem with a random seed.
+    let state: State<BenchmarkFunction> = config.optimize(&problem);
+
+    // Print the results.
+    println!("Found Individual: {:?}", state.best_individual().unwrap());
+    println!("This took {} iterations.", state.iterations());
+    println!("Global Optimum: {}", problem.known_optimum());
+}

--- a/examples/bmf_ga-pso.rs
+++ b/examples/bmf_ga-pso.rs
@@ -1,10 +1,20 @@
+use std::fs;
+use std::fs::File;
+use std::io::Write;
+use std::path::Path;
+use std::sync::Arc;
+
+use anyhow::Context;
 use itertools::Itertools;
+use rayon::prelude::*;
+
 use mahf::prelude::*;
+use mahf::tracking::files;
 use problems::bmf::BenchmarkFunction;
 use state::common::Iterations;
-use termination::LessThanN;
+use termination::{DistanceToOptGreaterThan, LessThanN};
 
-fn main() {
+fn main() -> anyhow::Result<()> {
     #[derive(Clone, serde::Serialize)]
     pub struct SplitFittest;
 
@@ -53,36 +63,118 @@ fn main() {
         }
     }
 
-    // Specify the problem: Sphere function with 10 dimensions.
-    let problem: BenchmarkFunction = BenchmarkFunction::rastrigin(/*dim: */ 30);
-    // Specify the metaheuristic: Particle Swarm Optimization (pre-implemented in MAHF).
+    let problems = [
+        BenchmarkFunction::rastrigin(/*dim: */ 30),
+        BenchmarkFunction::sphere(/*dim: */ 30),
+        BenchmarkFunction::ackley(/*dim: */ 30),
+    ];
+
     let config: Configuration<BenchmarkFunction> = Configuration::builder()
         .do_(initialization::RandomSpread::new_init(30))
         .evaluate()
         .update_best_individual()
         .do_(state::ParticleSwarm::initializer(1.))
-        .while_(LessThanN::<Iterations>::new(/*n: */ 500), |builder| {
-            builder
-                .do_(SplitFittest::new())
-                .do_(generation::recombination::ArithmeticCrossover::new_both(1.))
-                .do_(generation::mutation::GaussianMutation::new(0.2, 0.1))
-                .do_(SwapPopulations::new())
-                .do_(generation::swarm::ParticleSwarmGeneration::new(
-                    1., 1., 1., 1.,
-                ))
-                .do_(replacement::Merge::new())
-                .do_(constraints::Saturation::new())
-                .evaluate()
-                .update_best_individual()
-                .do_(state::ParticleSwarm::updater())
-        })
+        .while_(
+            LessThanN::<Iterations>::new(/*n: */ 1000) & DistanceToOptGreaterThan::new(0.01),
+            |builder| {
+                builder
+                    .do_(SplitFittest::new())
+                    .do_(generation::recombination::ArithmeticCrossover::new_both(1.))
+                    .do_(generation::mutation::GaussianMutation::new(0.2, 0.1))
+                    .do_(SwapPopulations::new())
+                    .do_(generation::swarm::ParticleSwarmGeneration::new(
+                        1., 1., 1., 1.,
+                    ))
+                    .do_(replacement::Merge::new())
+                    .do_(constraints::Saturation::new())
+                    .evaluate()
+                    .update_best_individual()
+                    .do_(state::ParticleSwarm::updater())
+                    .do_many_([
+                        state::diversity::TrueDiversity::new(),
+                        state::diversity::DimensionWiseDiversity::new(),
+                        state::diversity::DistanceToAveragePointDiversity::new(),
+                        state::diversity::PairwiseDistanceDiversity::new(),
+                    ])
+                    .do_(tracking::Logger::new())
+            },
+        )
         .build();
 
-    // Execute the metaheuristic on the problem with a random seed.
-    let state: State<BenchmarkFunction> = config.optimize(&problem);
+    experiment(config, logging, &problems, 50, "data/bmf/GA_PSO")
+}
 
-    // Print the results.
-    println!("Found Individual: {:?}", state.best_individual().unwrap());
-    println!("This took {} iterations.", state.iterations());
-    println!("Global Optimum: {}", problem.known_optimum());
+fn logging<P>(state: &mut State<P>)
+where
+    P: problems::SingleObjectiveProblem,
+    <P as problems::Problem>::Encoding: serde::Serialize,
+{
+    use tracking::extractor::normalized_diversity;
+    state.insert(
+        tracking::LogSet::<P>::new()
+            .with_many(
+                tracking::trigger::Iteration::new(1),
+                [
+                    normalized_diversity::<_, state::diversity::TrueDiversity>.into(),
+                    normalized_diversity::<_, state::diversity::DimensionWiseDiversity>.into(),
+                    normalized_diversity::<_, state::diversity::DistanceToAveragePointDiversity>
+                        .into(),
+                    normalized_diversity::<_, state::diversity::PairwiseDistanceDiversity>.into(),
+                ],
+            )
+            .with(
+                tracking::trigger::Iteration::new(5),
+                tracking::extractor::best_objective_value,
+            ),
+    )
+}
+
+fn experiment<P>(
+    config: Configuration<P>,
+    setup: impl Fn(&mut State<P>) + Send + Sync,
+    problems: &[P],
+    runs: u32,
+    folder: impl AsRef<Path>,
+) -> anyhow::Result<()>
+where
+    P: problems::SingleObjectiveProblem + problems::HasKnownOptimum + Send + Sync,
+    <P as problems::Problem>::Encoding: std::fmt::Debug,
+{
+    // Create data dir
+    let data_dir = Arc::new(folder.as_ref());
+    fs::create_dir_all(data_dir.as_ref())?;
+
+    // Write configuration RON file
+    let config_log_file = data_dir.join("configuration.ron");
+    ron::ser::to_writer_pretty(
+        std::io::BufWriter::new(
+            File::create(config_log_file).context("failed to create configuration file")?,
+        ),
+        config.heuristic(),
+        ron::ser::PrettyConfig::default().struct_names(true),
+    )
+    .context("failed to serialize configuration")?;
+
+    (0..runs)
+        .into_par_iter()
+        .map(|run| {
+            for problem in problems {
+                let log_file = data_dir.join(format!("{}_{run}.log", problem.name()));
+                let state = config.optimize_with(problem, |state| {
+                    state.insert(Random::seeded(run as u64));
+                    setup(state);
+                });
+                files::write_log_file(log_file, state.log())?;
+                println!("Finished run {run}.");
+                println!("Found Individual: {:?}", state.best_individual().unwrap());
+                println!("This took {} iterations.", state.iterations());
+                println!("Global Optimum: {:?}", problem.known_optimum());
+                std::io::stdout().flush().unwrap();
+            }
+            Ok(())
+        })
+        .collect::<anyhow::Result<()>>()?;
+
+    println!("All runs finished.");
+    Ok(())
 }

--- a/examples/bmf_ga-pso.rs
+++ b/examples/bmf_ga-pso.rs
@@ -1,0 +1,88 @@
+use itertools::Itertools;
+use mahf::prelude::*;
+use problems::bmf::BenchmarkFunction;
+use state::common::Iterations;
+use termination::LessThanN;
+
+fn main() {
+    #[derive(Clone, serde::Serialize)]
+    pub struct SplitFittest;
+
+    impl SplitFittest {
+        #[allow(clippy::new_ret_no_self)]
+        pub fn new<P: problems::SingleObjectiveProblem>() -> Box<dyn Component<P>> {
+            Box::new(Self)
+        }
+    }
+
+    impl<P: problems::SingleObjectiveProblem> Component<P> for SplitFittest {
+        #[contracts::requires(state.populations().current().len() % 2 == 0)]
+        fn execute(&self, _problem: &P, state: &mut State<P>) {
+            let mut population = state.populations_mut().pop();
+            population.sort_unstable_by_key(|i| *i.objective());
+            let n = population.len();
+            let (lower, upper) = population
+                .into_iter()
+                .chunks(n / 2)
+                .into_iter()
+                .map(|c| c.collect_vec())
+                .collect_tuple::<(_, _)>()
+                .unwrap();
+            state.populations_mut().push(upper);
+            state.populations_mut().push(lower);
+        }
+    }
+
+    #[derive(Clone, serde::Serialize)]
+    pub struct SwapPopulations;
+
+    impl SwapPopulations {
+        #[allow(clippy::new_ret_no_self)]
+        pub fn new<P: problems::Problem>() -> Box<dyn Component<P>> {
+            Box::new(Self)
+        }
+    }
+
+    impl<P: problems::Problem> Component<P> for SwapPopulations {
+        #[contracts::requires(state.populations().len() >= 2)]
+        fn execute(&self, _problem: &P, state: &mut State<P>) {
+            let p1 = state.populations_mut().pop();
+            let p2 = state.populations_mut().pop();
+            state.populations_mut().push(p1);
+            state.populations_mut().push(p2);
+        }
+    }
+
+    // Specify the problem: Sphere function with 10 dimensions.
+    let problem: BenchmarkFunction = BenchmarkFunction::rastrigin(/*dim: */ 30);
+    // Specify the metaheuristic: Particle Swarm Optimization (pre-implemented in MAHF).
+    let config: Configuration<BenchmarkFunction> = Configuration::builder()
+        .do_(initialization::RandomSpread::new_init(30))
+        .evaluate()
+        .update_best_individual()
+        .do_(state::ParticleSwarm::initializer(1.))
+        .while_(LessThanN::<Iterations>::new(/*n: */ 500), |builder| {
+            builder
+                .do_(SplitFittest::new())
+                .do_(generation::recombination::ArithmeticCrossover::new_both(1.))
+                .do_(generation::mutation::GaussianMutation::new(0.2, 0.1))
+                .do_(SwapPopulations::new())
+                .do_(generation::swarm::ParticleSwarmGeneration::new(
+                    1., 1., 1., 1.,
+                ))
+                .do_(replacement::Merge::new())
+                .do_(constraints::Saturation::new())
+                .evaluate()
+                .update_best_individual()
+                .do_(state::ParticleSwarm::updater())
+        })
+        .build();
+
+    // Execute the metaheuristic on the problem with a random seed.
+    let state: State<BenchmarkFunction> = config.optimize(&problem);
+
+    // Print the results.
+    println!("Found Individual: {:?}", state.best_individual().unwrap());
+    println!("This took {} iterations.", state.iterations());
+    println!("Global Optimum: {}", problem.known_optimum());
+}

--- a/examples/bmf_pso-sa.rs
+++ b/examples/bmf_pso-sa.rs
@@ -38,16 +38,16 @@ fn main() {
     }
 
     #[derive(Clone, serde::Serialize)]
-    pub struct GlobalBestIntoPopulation;
+    pub struct GlobalBestToPopulation;
 
-    impl GlobalBestIntoPopulation {
+    impl GlobalBestToPopulation {
         #[allow(clippy::new_ret_no_self)]
         pub fn new<P: problems::SingleObjectiveProblem>() -> Box<dyn Component<P>> {
             Box::new(Self)
         }
     }
 
-    impl<P: problems::SingleObjectiveProblem> Component<P> for GlobalBestIntoPopulation {
+    impl<P: problems::SingleObjectiveProblem> Component<P> for GlobalBestToPopulation {
         fn require(&self, _problem: &P, state: &State<P>) {
             state.require::<Self, state::ParticleSwarm<P>>();
         }
@@ -81,7 +81,7 @@ fn main() {
     }
 
     let constraints = constraints::Saturation::new();
-    let cooling_schedule = mapping::GeometricCooling::new::<_, replacement::Temperature>(0.99);
+    let cooling_schedule = mapping::GeometricCooling::new::<_, replacement::Temperature>(0.95);
 
     // Specify the problem: Sphere function with 10 dimensions.
     let problem: BenchmarkFunction = BenchmarkFunction::rastrigin(/*dim: */ 30);
@@ -94,7 +94,7 @@ fn main() {
         // Outer PSO loop.
         .while_(
             termination::LessThanN::<state::common::Iterations>::new(/*n: */ 10_000)
-                & termination::DistanceToOpt::new(0.01),
+                & termination::DistanceToOptGreaterThan::new(0.01),
             |builder| {
                 builder
                     .do_(generation::swarm::ParticleSwarmGeneration::new(
@@ -109,10 +109,10 @@ fn main() {
                         !GlobalBestImproved::new(),
                         |builder| {
                             builder
-                                .do_(GlobalBestIntoPopulation::new())
+                                .do_(GlobalBestToPopulation::new())
                                 .do_(sa::sa(
                                     sa::Parameters {
-                                        t_0: 1000.,
+                                        t_0: 1.,
                                         generation: generation::mutation::GaussianMutation::new(
                                             1., 0.1,
                                         ),

--- a/examples/bmf_pso-sa.rs
+++ b/examples/bmf_pso-sa.rs
@@ -1,0 +1,139 @@
+use mahf::prelude::*;
+use problems::bmf::BenchmarkFunction;
+
+fn main() {
+    #[derive(derive_more::Deref, derive_more::DerefMut, better_any::Tid)]
+    struct PreviousObjectiveValue(framework::SingleObjective);
+
+    impl state::CustomState<'_> for PreviousObjectiveValue {}
+
+    #[derive(Clone, serde::Serialize)]
+    pub struct GlobalBestImproved;
+
+    impl GlobalBestImproved {
+        #[allow(clippy::new_ret_no_self)]
+        pub fn new<P: problems::SingleObjectiveProblem>() -> Box<dyn Condition<P>> {
+            Box::new(Self)
+        }
+    }
+
+    impl<P: problems::SingleObjectiveProblem> Condition<P> for GlobalBestImproved {
+        fn initialize(&self, _problem: &P, state: &mut State<P>) {
+            state.insert(PreviousObjectiveValue(framework::SingleObjective::default()));
+        }
+
+        fn require(&self, _problem: &P, state: &State<P>) {
+            state.require::<Self, state::ParticleSwarm<P>>();
+        }
+
+        fn evaluate(&self, _problem: &P, state: &mut State<P>) -> bool {
+            let mut mut_state = state.get_states_mut();
+            let state::ParticleSwarm { global_best, .. } =
+                mut_state.get_mut::<state::ParticleSwarm<P>>();
+            let previous = mut_state.get_value::<PreviousObjectiveValue>();
+            mut_state.set_value::<PreviousObjectiveValue>(*global_best.objective());
+
+            global_best.objective() < &previous
+        }
+    }
+
+    #[derive(Clone, serde::Serialize)]
+    pub struct GlobalBestIntoPopulation;
+
+    impl GlobalBestIntoPopulation {
+        #[allow(clippy::new_ret_no_self)]
+        pub fn new<P: problems::SingleObjectiveProblem>() -> Box<dyn Component<P>> {
+            Box::new(Self)
+        }
+    }
+
+    impl<P: problems::SingleObjectiveProblem> Component<P> for GlobalBestIntoPopulation {
+        fn require(&self, _problem: &P, state: &State<P>) {
+            state.require::<Self, state::ParticleSwarm<P>>();
+        }
+
+        fn execute(&self, _problem: &P, state: &mut State<P>) {
+            let best = state.get::<state::ParticleSwarm<P>>().global_best.clone();
+            state.populations_mut().push(vec![best]);
+        }
+    }
+
+    #[derive(Clone, serde::Serialize)]
+    pub struct SingleToGlobalBest;
+
+    impl SingleToGlobalBest {
+        #[allow(clippy::new_ret_no_self)]
+        pub fn new<P: problems::SingleObjectiveProblem>() -> Box<dyn Component<P>> {
+            Box::new(Self)
+        }
+    }
+
+    impl<P: problems::SingleObjectiveProblem> Component<P> for SingleToGlobalBest {
+        fn require(&self, _problem: &P, state: &State<P>) {
+            state.require::<Self, state::ParticleSwarm<P>>();
+        }
+
+        #[contracts::requires(state.populations().current().len() == 1)]
+        fn execute(&self, _problem: &P, state: &mut State<P>) {
+            let best = state.populations_mut().pop().into_iter().next().unwrap();
+            state.get_mut::<state::ParticleSwarm<P>>().global_best = best;
+        }
+    }
+
+    let constraints = constraints::Saturation::new();
+    let cooling_schedule = mapping::GeometricCooling::new::<_, replacement::Temperature>(0.99);
+
+    // Specify the problem: Sphere function with 10 dimensions.
+    let problem: BenchmarkFunction = BenchmarkFunction::rastrigin(/*dim: */ 30);
+    // Specify the metaheuristic: Particle Swarm Optimization (pre-implemented in MAHF).
+    let config: Configuration<BenchmarkFunction> = Configuration::builder()
+        .do_(initialization::RandomSpread::new_init(4 * 30))
+        .evaluate()
+        .update_best_individual()
+        .do_(state::ParticleSwarm::initializer(1.))
+        // Outer PSO loop.
+        .while_(
+            termination::LessThanN::<state::common::Iterations>::new(/*n: */ 10_000)
+                & termination::DistanceToOpt::new(0.01),
+            |builder| {
+                builder
+                    .do_(generation::swarm::ParticleSwarmGeneration::new(
+                        1., 1., 1., 1.,
+                    ))
+                    .do_(constraints.clone())
+                    .evaluate()
+                    .update_best_individual()
+                    .do_(state::ParticleSwarm::updater())
+                    // SA is run if the global best did not change.
+                    .if_else_(
+                        !GlobalBestImproved::new(),
+                        |builder| {
+                            builder
+                                .do_(GlobalBestIntoPopulation::new())
+                                .do_(sa::sa(
+                                    sa::Parameters {
+                                        t_0: 1000.,
+                                        generation: generation::mutation::GaussianMutation::new(
+                                            1., 0.1,
+                                        ),
+                                        cooling_schedule: cooling_schedule.clone(),
+                                        constraints,
+                                    },
+                                    termination::StepsWithoutImprovement::new(1),
+                                ))
+                                .do_(SingleToGlobalBest::new())
+                        },
+                        |builder| builder.do_(cooling_schedule.clone()),
+                    )
+            },
+        )
+        .build();
+
+    // Execute the metaheuristic on the problem with a random seed.
+    let state: State<BenchmarkFunction> = config.optimize(&problem);
+
+    // Print the results.
+    println!("Found Individual: {:?}", state.best_individual().unwrap());
+    println!("This took {} iterations.", state.iterations());
+    println!("Global Optimum: {}", problem.known_optimum());
+}

--- a/examples/coco.rs
+++ b/examples/coco.rs
@@ -1,6 +1,6 @@
 use mahf::{prelude::*, state::common, tracking::LogSet};
 use problems::coco_bound::{suits, CocoInstance};
-use tracking::{functions, trigger};
+use tracking::{extractor, trigger};
 
 fn main() -> anyhow::Result<()> {
     let output = "data/coco/iwo";
@@ -24,9 +24,9 @@ fn main() -> anyhow::Result<()> {
                 .with_common_extractors(trigger::Iteration::new(10))
                 .with(
                     trigger::Change::<common::Progress<common::Iterations>>::new(0.1),
-                    functions::auto::<common::Progress<common::Iterations>, _>,
+                    extractor::auto::<common::Progress<common::Iterations>, _>,
                 )
-                .with(trigger::Iteration::new(50), functions::best_individual),
+                .with(trigger::Iteration::new(50), extractor::best_individual),
         )
     })
 }

--- a/examples/coco.rs
+++ b/examples/coco.rs
@@ -23,8 +23,8 @@ fn main() -> anyhow::Result<()> {
             LogSet::<CocoInstance>::new()
                 .with_common_extractors(trigger::Iteration::new(10))
                 .with(
-                    trigger::Change::<common::Progress>::new(0.1),
-                    functions::auto::<common::Progress, _>,
+                    trigger::Change::<common::Progress<common::Iterations>>::new(0.1),
+                    functions::auto::<common::Progress<common::Iterations>, _>,
                 )
                 .with(trigger::Iteration::new(50), functions::best_individual),
         )

--- a/examples/tsp.rs
+++ b/examples/tsp.rs
@@ -1,7 +1,7 @@
 use aco::ant_ops;
 use mahf::prelude::*;
 use problems::tsp::{self, SymmetricTsp};
-use tracking::{files, functions, trigger};
+use tracking::{extractor, files, trigger};
 
 fn main() {
     // Specify the problem: TSPLIB instance Berlin52.
@@ -34,7 +34,7 @@ fn main() {
         // Log the best individual every 50 iterations.
         state.insert(
             tracking::LogSet::<SymmetricTsp>::new()
-                .with(trigger::Iteration::new(50), functions::best_individual),
+                .with(trigger::Iteration::new(50), extractor::best_individual),
         );
     });
 

--- a/src/components/control_flow.rs
+++ b/src/components/control_flow.rs
@@ -32,6 +32,12 @@ impl<P: Problem> Component<P> for Block<P> {
         }
     }
 
+    fn require(&self, problem: &P, state: &State<P>) {
+        for component in &self.0 {
+            component.require(problem, state);
+        }
+    }
+
     fn execute(&self, problem: &P, state: &mut State<P>) {
         for component in &self.0 {
             component.execute(problem, state);
@@ -79,6 +85,11 @@ impl<P: Problem> Component<P> for Loop<P> {
 
         self.condition.initialize(problem, state);
         self.body.initialize(problem, state);
+    }
+
+    fn require(&self, problem: &P, state: &State<P>) {
+        self.condition.require(problem, state);
+        self.body.require(problem, state);
     }
 
     fn execute(&self, problem: &P, state: &mut State<P>) {
@@ -145,6 +156,14 @@ impl<P: Problem> Component<P> for Branch<P> {
         self.if_body.initialize(problem, state);
         if let Some(else_body) = &self.else_body {
             else_body.initialize(problem, state);
+        }
+    }
+
+    fn require(&self, problem: &P, state: &State<P>) {
+        self.condition.require(problem, state);
+        self.if_body.require(problem, state);
+        if let Some(else_body) = &self.else_body {
+            else_body.require(problem, state);
         }
     }
 

--- a/src/components/generation/mutation.rs
+++ b/src/components/generation/mutation.rs
@@ -5,6 +5,7 @@ use rand::{prelude::SliceRandom, seq::IteratorRandom, Rng};
 use rand_distr::Distribution;
 use serde::{Deserialize, Serialize};
 
+use crate::state::common;
 use crate::{
     components::Component,
     framework::{AnyComponent, Individual},
@@ -144,7 +145,7 @@ where
         _problem: &P,
         state: &mut State<P>,
     ) {
-        let deviation = self.deviation(state.get_value::<Progress>());
+        let deviation = self.deviation(state.get_value::<Progress<common::Iterations>>());
         let distribution = rand_distr::Normal::new(0.0, deviation).unwrap();
 
         for solution in population {

--- a/src/components/generation/swarm.rs
+++ b/src/components/generation/swarm.rs
@@ -16,9 +16,8 @@ use crate::{
 
 /// Inertia weight for influence of old velocity.
 #[derive(Deref, DerefMut, Tid)]
-pub struct Weight(pub f64);
-
-impl CustomState<'_> for Weight {}
+pub struct InertiaWeight(pub f64);
+impl CustomState<'_> for InertiaWeight {}
 
 /// Applies the PSO specific generation operator.
 ///
@@ -54,7 +53,7 @@ where
     P: SingleObjectiveProblem<Encoding = Vec<f64>>,
 {
     fn initialize(&self, _problem: &P, state: &mut State<P>) {
-        state.insert(Weight(self.weight));
+        state.insert(InertiaWeight(self.weight));
     }
 
     fn require(&self, _problem: &P, state: &State<P>) {
@@ -79,7 +78,7 @@ where
             global_best,
         } = mut_state.get_mut::<ParticleSwarm<P>>();
 
-        let w = mut_state.get_value::<Weight>();
+        let w = mut_state.get_value::<InertiaWeight>();
 
         let mut rand = move || rng.gen::<f64>();
 

--- a/src/components/mapping.rs
+++ b/src/components/mapping.rs
@@ -1,0 +1,101 @@
+use rand::distributions::uniform::SampleRange;
+use rand::Rng;
+use serde::Serialize;
+use std::marker::PhantomData;
+use trait_set::trait_set;
+
+use crate::{
+    components::Component, framework::AnyComponent, problems::Problem, state::State, CustomState,
+};
+
+pub trait Mapping<D, P: Problem> {
+    fn map(&self, value: D, problem: &P, state: &mut State<P>) -> D;
+}
+
+#[derive(Serialize, derivative::Derivative)]
+#[derivative(Clone(bound = ""))]
+pub struct Mapper<T, X, S>(pub T, PhantomData<fn() -> (X, S)>)
+where
+    T: Clone;
+
+impl<T, X, S> Mapper<T, X, S>
+where
+    T: Clone,
+{
+    pub fn new(schedule: T) -> Self {
+        Self(schedule, PhantomData)
+    }
+}
+
+impl<T, D, X, S, P> Component<P> for Mapper<T, X, S>
+where
+    P: Problem,
+    T: AnyComponent + Mapping<D, P> + Serialize + Clone,
+    D: Copy,
+    X: for<'a> CustomState<'a> + std::ops::Deref<Target = D>,
+    S: for<'a> CustomState<'a> + std::ops::DerefMut<Target = D>,
+{
+    fn require(&self, _problem: &P, state: &State<P>) {
+        state.require::<Self, S>();
+    }
+
+    fn execute(&self, problem: &P, state: &mut State<P>) {
+        let value = state.get_value::<X>();
+        let result = self.0.map(value, problem, state);
+        state.set_value::<S>(result);
+    }
+}
+
+#[derive(Clone, Serialize)]
+pub struct Linear {
+    pub start: f64,
+    pub end: f64,
+}
+
+impl Linear {
+    pub fn new<P, X, S>(start: f64, end: f64) -> Box<dyn Component<P>>
+    where
+        P: Problem,
+        X: for<'a> CustomState<'a> + std::ops::Deref<Target = f64>,
+        S: for<'a> CustomState<'a> + std::ops::DerefMut<Target = f64>,
+    {
+        Box::new(Mapper::<_, X, S>::new(Self { start, end }))
+    }
+}
+
+impl<P: Problem> Mapping<f64, P> for Linear {
+    fn map(&self, value: f64, _problem: &P, _state: &mut State<P>) -> f64 {
+        (self.end - self.start) * value + self.start
+    }
+}
+
+trait_set! {
+    pub trait RandomRange = SampleRange<f64> + Clone + Serialize + Send + Sync + 'static;
+}
+
+#[derive(Clone, Serialize)]
+pub struct Random<R: RandomRange>(pub R);
+
+impl<R> Random<R>
+where
+    R: RandomRange,
+{
+    pub fn new<P, X, S>(range: R) -> Box<dyn Component<P>>
+    where
+        P: Problem,
+        X: for<'a> CustomState<'a> + std::ops::Deref<Target = f64>,
+        S: for<'a> CustomState<'a> + std::ops::DerefMut<Target = f64>,
+    {
+        Box::new(Mapper::<_, X, S>::new(Self(range)))
+    }
+}
+
+impl<P, R> Mapping<f64, P> for Random<R>
+where
+    R: RandomRange,
+    P: Problem,
+{
+    fn map(&self, _value: f64, _problem: &P, state: &mut State<P>) -> f64 {
+        state.random_mut().gen_range(self.0.clone())
+    }
+}

--- a/src/components/misc.rs
+++ b/src/components/misc.rs
@@ -115,5 +115,6 @@ where
             println!("No solution found.")
         }
         println!("{}", "-".repeat(heading.len()));
+        println!();
     }
 }

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -15,6 +15,7 @@ pub mod initialization;
 pub mod misc;
 pub mod replacement;
 pub mod selection;
+pub mod mapping;
 
 /// Trait to represent a *component*, a (small) functionality with a common interface.
 ///

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -12,10 +12,10 @@ pub use control_flow::{Block, Branch, Loop, Scope};
 pub mod evaluation;
 pub mod generation;
 pub mod initialization;
+pub mod mapping;
 pub mod misc;
 pub mod replacement;
 pub mod selection;
-pub mod mapping;
 
 /// Trait to represent a *component*, a (small) functionality with a common interface.
 ///

--- a/src/conditions/mod.rs
+++ b/src/conditions/mod.rs
@@ -20,6 +20,8 @@ pub mod termination;
 pub trait Condition<P: Problem>: AnyComponent {
     #[allow(unused_variables)]
     fn initialize(&self, problem: &P, state: &mut State<P>) {}
+    #[allow(unused_variables)]
+    fn require(&self, problem: &P, state: &State<P>) {}
     fn evaluate(&self, problem: &P, state: &mut State<P>) -> bool;
 }
 

--- a/src/conditions/termination.rs
+++ b/src/conditions/termination.rs
@@ -229,12 +229,12 @@ mod fixed_evaluations {
 ///
 /// Progress is unknown, as optimizer should not have information on optimum.
 #[derive(Serialize, Deserialize, Clone)]
-pub struct DistanceToOpt {
+pub struct DistanceToOptGreaterThan {
     /// Distance to known optimum.
     pub distance: f64,
 }
 
-impl DistanceToOpt {
+impl DistanceToOptGreaterThan {
     pub fn new<P: HasKnownOptimum>(distance: f64) -> Box<dyn Condition<P>>
     where
         P: SingleObjectiveProblem,
@@ -243,7 +243,7 @@ impl DistanceToOpt {
     }
 }
 
-impl<P: HasKnownOptimum + SingleObjectiveProblem> Condition<P> for DistanceToOpt
+impl<P: HasKnownOptimum + SingleObjectiveProblem> Condition<P> for DistanceToOptGreaterThan
 where
     P: Problem,
 {
@@ -264,7 +264,7 @@ mod distance_to_opt {
         let problem = TestProblem;
         let mut state = State::new();
         state.insert(common::BestIndividual::<TestProblem>::default());
-        let comp = DistanceToOpt { distance: 0.1 };
+        let comp = DistanceToOptGreaterThan { distance: 0.1 };
 
         state.set_value::<common::BestIndividual<TestProblem>>(Some(new_test_individual(0.2)));
         assert!(comp.evaluate(&problem, &mut state));

--- a/src/framework/configuration.rs
+++ b/src/framework/configuration.rs
@@ -36,6 +36,12 @@ impl<P: Problem> Configuration<P> {
         ConfigurationBuilder::new().do_(self.0)
     }
 
+    pub fn run(&self, problem: &P, state: &mut state::State<P>) {
+        self.0.initialize(problem, state);
+        self.0.require(problem, state);
+        self.0.execute(problem, state);
+    }
+
     /// Runs the heuristic on the given problem, returning the final state of the heuristic.
     ///
     /// The state is pre-initialized with a [Population][state::common::Population]
@@ -45,15 +51,13 @@ impl<P: Problem> Configuration<P> {
     /// For initializing the state with custom state,
     /// see [optimize_with][Configuration::optimize_with].
     pub fn optimize(&self, problem: &P) -> state::State<P> {
-        let heuristic = self.heuristic();
         let mut state = state::State::new();
 
         state.insert(tracking::Log::new());
         state.insert(Random::default());
         state.insert(state::common::Populations::<P>::new());
 
-        heuristic.initialize(problem, &mut state);
-        heuristic.execute(problem, &mut state);
+        self.run(problem, &mut state);
 
         state
     }
@@ -70,7 +74,6 @@ impl<P: Problem> Configuration<P> {
         problem: &P,
         init_state: impl FnOnce(&mut state::State<'a, P>),
     ) -> state::State<'a, P> {
-        let heuristic = self.heuristic();
         let mut state = state::State::new();
 
         state.insert(tracking::Log::new());
@@ -82,8 +85,7 @@ impl<P: Problem> Configuration<P> {
             state.insert(Random::default());
         }
 
-        heuristic.initialize(problem, &mut state);
-        heuristic.execute(problem, &mut state);
+        self.run(problem, &mut state);
 
         state
     }

--- a/src/framework/individual.rs
+++ b/src/framework/individual.rs
@@ -129,6 +129,7 @@ pub trait PopulationExtensions<P: Problem> {
     fn into_solutions(self) -> Vec<P::Encoding>
     where
         Self: Sized;
+    fn into_single(self) -> Individual<P>;
 }
 
 impl<P> PopulationExtensions<P> for Vec<Individual<P>>
@@ -148,5 +149,9 @@ where
         Self: Sized,
     {
         self.into_iter().map(Individual::into_solution).collect()
+    }
+
+    fn into_single(self) -> Individual<P> {
+        self.into_iter().next().unwrap()
     }
 }

--- a/src/framework/individual.rs
+++ b/src/framework/individual.rs
@@ -122,3 +122,31 @@ impl<E: Debug, P: Problem<Encoding = E>> Debug for Individual<P> {
         )
     }
 }
+
+pub trait PopulationExtensions<P: Problem> {
+    fn solutions(&self) -> Vec<&P::Encoding>;
+    fn solutions_mut(&mut self) -> Vec<&mut P::Encoding>;
+    fn into_solutions(self) -> Vec<P::Encoding>
+    where
+        Self: Sized;
+}
+
+impl<P> PopulationExtensions<P> for Vec<Individual<P>>
+where
+    P: Problem,
+{
+    fn solutions(&self) -> Vec<&P::Encoding> {
+        self.iter().map(Individual::solution).collect()
+    }
+
+    fn solutions_mut(&mut self) -> Vec<&mut P::Encoding> {
+        self.iter_mut().map(Individual::solution_mut).collect()
+    }
+
+    fn into_solutions(self) -> Vec<P::Encoding>
+    where
+        Self: Sized,
+    {
+        self.into_iter().map(Individual::into_solution).collect()
+    }
+}

--- a/src/framework/mod.rs
+++ b/src/framework/mod.rs
@@ -9,7 +9,7 @@ mod objective;
 pub use objective::{IllegalObjective, MultiObjective, Objective, SingleObjective};
 
 mod individual;
-pub use individual::Individual;
+pub use individual::{Individual, PopulationExtensions};
 
 trait_set! {
     /// Collection of traits required by every component.

--- a/src/heuristics/de.rs
+++ b/src/heuristics/de.rs
@@ -45,7 +45,7 @@ where
                 mutation: generation::mutation::DEMutation::new(y, f),
                 crossover: generation::recombination::DEBinomialCrossover::new(pc),
                 constraints: constraints::Saturation::new(),
-                replacement: replacement::IndividualPlus::new(),
+                replacement: replacement::KeepBetterAtIndex::new(),
             },
             termination,
             logger,

--- a/src/heuristics/mod.rs
+++ b/src/heuristics/mod.rs
@@ -11,3 +11,4 @@ pub mod ls;
 pub mod pso;
 pub mod rs;
 pub mod rw;
+pub mod sa;

--- a/src/heuristics/pso.rs
+++ b/src/heuristics/pso.rs
@@ -53,8 +53,8 @@ where
                 constraints: constraints::Saturation::new(),
                 inertia_weight_update: Some(mapping::Linear::new::<
                     _,
-                    state::common::Progress,
-                    generation::swarm::Weight,
+                    state::common::Progress<state::common::Iterations>,
+                    generation::swarm::InertiaWeight,
                 >(start_weight, end_weight)),
                 state_update: state::ParticleSwarm::updater(),
             },

--- a/src/heuristics/sa.rs
+++ b/src/heuristics/sa.rs
@@ -1,0 +1,121 @@
+//! Local Search
+
+use crate::{
+    components::*,
+    conditions::Condition,
+    framework::Configuration,
+    problems::{LimitedVectorProblem, SingleObjectiveProblem, VectorProblem},
+    tracking::Logger,
+};
+
+/// Parameters for [real_sa].
+pub struct RealProblemParameters {
+    pub t_0: f64,
+    pub alpha: f64,
+    pub deviation: f64,
+}
+
+/// An example single-objective Local Search operating on a real search space.
+/// Uses the [sa] component internally.
+pub fn real_sa<P>(
+    params: RealProblemParameters,
+    termination: Box<dyn Condition<P>>,
+) -> Configuration<P>
+where
+    P: SingleObjectiveProblem<Encoding = Vec<f64>> + VectorProblem<T = f64> + LimitedVectorProblem,
+{
+    let RealProblemParameters {
+        t_0,
+        alpha,
+        deviation,
+    } = params;
+
+    Configuration::builder()
+        .do_(initialization::RandomSpread::new_init(1))
+        .evaluate()
+        .update_best_individual()
+        .do_(evaluation::UpdateBestIndividual::new())
+        .do_(sa(
+            Parameters {
+                t_0,
+                generation: generation::mutation::FixedDeviationDelta::new(deviation),
+                cooling_schedule: mapping::GeometricCooling::new::<_, replacement::Temperature>(
+                    alpha,
+                ),
+                constraints: constraints::Saturation::new(),
+            },
+            termination,
+        ))
+        .build()
+}
+
+/// Parameters for [permutation_sa].
+pub struct PermutationProblemParameters {
+    pub t_0: f64,
+    pub alpha: f64,
+    pub n_swap: usize,
+}
+
+/// An example single-objective Simulated Annealing operating on a permutation search space.
+/// Uses the [sa] component internally.
+pub fn permutation_sa<P>(
+    params: PermutationProblemParameters,
+    termination: Box<dyn Condition<P>>,
+) -> Configuration<P>
+where
+    P: SingleObjectiveProblem<Encoding = Vec<usize>> + VectorProblem<T = usize>,
+{
+    let PermutationProblemParameters { t_0, alpha, n_swap } = params;
+
+    Configuration::builder()
+        .do_(initialization::RandomPermutation::new_init(1))
+        .evaluate()
+        .update_best_individual()
+        .do_(sa(
+            Parameters {
+                t_0,
+                generation: generation::mutation::SwapMutation::new(n_swap),
+                cooling_schedule: mapping::GeometricCooling::new::<_, replacement::Temperature>(
+                    alpha,
+                ),
+                constraints: misc::Noop::new(),
+            },
+            termination,
+        ))
+        .build()
+}
+
+/// Basic building blocks of a Local Search.
+pub struct Parameters<P> {
+    pub t_0: f64,
+    pub generation: Box<dyn Component<P>>,
+    pub cooling_schedule: Box<dyn Component<P>>,
+    pub constraints: Box<dyn Component<P>>,
+}
+
+/// A generic single-objective Simulated Annealing template.
+pub fn sa<P: SingleObjectiveProblem>(
+    params: Parameters<P>,
+    termination: Box<dyn Condition<P>>,
+) -> Box<dyn Component<P>> {
+    let Parameters {
+        t_0,
+        generation,
+        cooling_schedule,
+        constraints,
+    } = params;
+
+    Configuration::builder()
+        .while_(termination, |builder| {
+            builder
+                .do_(selection::All::new())
+                .do_(generation)
+                .do_(constraints)
+                .evaluate()
+                .update_best_individual()
+                .do_(cooling_schedule)
+                .do_(replacement::ExponentialAnnealingAcceptance::new(t_0))
+                .do_(Logger::new())
+        })
+        .build_component()
+}

--- a/src/state/common.rs
+++ b/src/state/common.rs
@@ -81,17 +81,22 @@ impl<P: SingleObjectiveProblem> Default for BestIndividual<P> {
     }
 }
 
-#[derive(Deref, DerefMut, Clone, Serialize, Tid)]
+#[derive(Deref, DerefMut, Clone, Serialize, Tid, Default)]
 pub struct Evaluations(pub u32);
 impl CustomState<'_> for Evaluations {}
 
-#[derive(Deref, DerefMut, Clone, Serialize, Tid)]
+#[derive(Deref, DerefMut, Clone, Serialize, Tid, Default)]
 pub struct Iterations(pub u32);
 impl CustomState<'_> for Iterations {}
 
-#[derive(Deref, DerefMut, Clone, Serialize, Tid)]
-pub struct Progress(pub f64);
-impl CustomState<'_> for Progress {}
+#[derive(Deref, DerefMut, Clone, Serialize, Tid, Default)]
+pub struct Progress<T: 'static>(
+    #[deref]
+    #[deref_mut]
+    pub f64,
+    std::marker::PhantomData<fn() -> T>,
+);
+impl<T> CustomState<'_> for Progress<T> {}
 
 /// Saves non-pareto-dominated [Individual]'s.
 ///
@@ -174,5 +179,9 @@ impl<P: Problem> Populations<P> {
 
     pub fn is_empty(&self) -> bool {
         self.stack.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.stack.len()
     }
 }

--- a/src/state/diversity.rs
+++ b/src/state/diversity.rs
@@ -30,12 +30,12 @@ where
     I: AnyComponent + DiversityMeasure<P> + Serialize + Clone,
 {
     fn initialize(&self, _problem: &P, state: &mut State<P>) {
-        state.insert(DiversityState::<I>::default());
+        state.insert(NormalizedDiversity::<I>::default());
     }
 
     fn execute(&self, problem: &P, state: &mut State<P>) {
         let (populations, diversity_state) =
-            state.get_multiple_mut::<(Populations<P>, DiversityState<I>)>();
+            state.get_multiple_mut::<(Populations<P>, NormalizedDiversity<I>)>();
 
         let population = populations.current();
 
@@ -177,14 +177,14 @@ impl<P: Problem<Encoding = Vec<f64>> + VectorProblem<T = f64>> DiversityMeasure<
 
 /// State for logging/tracking population diversity.
 #[derive(Debug, Tid)]
-pub struct DiversityState<I: 'static> {
+pub struct NormalizedDiversity<I: 'static> {
     /// Normalized diversity.
     pub diversity: f64,
     /// Non-normalized maximal diversity.
     pub max_diversity: f64,
     phantom: PhantomData<I>,
 }
-impl<I> Default for DiversityState<I> {
+impl<I> Default for NormalizedDiversity<I> {
     fn default() -> Self {
         Self {
             diversity: 0.0,
@@ -194,4 +194,4 @@ impl<I> Default for DiversityState<I> {
     }
 }
 
-impl<I: Send + 'static> CustomState<'_> for DiversityState<I> {}
+impl<I: Send + 'static> CustomState<'_> for NormalizedDiversity<I> {}

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -8,7 +8,7 @@ pub mod common;
 pub mod diversity;
 
 pub mod pso;
-pub use pso::{ParticleSwarm};
+pub use pso::ParticleSwarm;
 
 mod pheromones;
 pub use pheromones::PheromoneMatrix;

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -7,8 +7,8 @@ pub mod archive;
 pub mod common;
 pub mod diversity;
 
-mod pso;
-pub use pso::PsoState;
+pub mod pso;
+pub use pso::{ParticleSwarm};
 
 mod pheromones;
 pub use pheromones::PheromoneMatrix;

--- a/src/state/pso.rs
+++ b/src/state/pso.rs
@@ -1,9 +1,11 @@
 use better_any::Tid;
+use derive_more::{Deref, DerefMut};
+use itertools::{multizip, Itertools};
 use rand::Rng;
 
 use crate::{
     components::Component,
-    framework::Individual,
+    framework::{Individual, SingleObjective},
     problems::{LimitedVectorProblem, Problem, SingleObjectiveProblem},
     state::{CustomState, State},
 };
@@ -12,34 +14,83 @@ use crate::{
 ///
 /// For preserving velocities of particles, own best values and global best particle.
 #[derive(Tid)]
-pub struct PsoState<P: Problem + 'static> {
+pub struct ParticleSwarm<P: Problem + 'static> {
     pub velocities: Vec<Vec<f64>>,
     pub bests: Vec<Individual<P>>,
     pub global_best: Individual<P>,
 }
 
-impl<P: Problem> CustomState<'_> for PsoState<P> {}
+impl<P: Problem> CustomState<'_> for ParticleSwarm<P> {}
 
-impl<P: Problem> PsoState<P>
+#[derive(Deref, DerefMut, Tid)]
+pub struct ImprovedParticlePercentage(pub f64);
+
+impl CustomState<'_> for ImprovedParticlePercentage {}
+
+#[derive(Deref, DerefMut, Tid)]
+struct PreviousObjectiveValues(Vec<SingleObjective>);
+
+impl CustomState<'_> for PreviousObjectiveValues {}
+
+#[derive(Clone, serde::Serialize)]
+pub struct UpdateImprovedParticlePercentage {
+    pub delta: f64,
+}
+
+impl UpdateImprovedParticlePercentage {
+    pub fn new<P: SingleObjectiveProblem>(delta: f64) -> Box<dyn Component<P>> {
+        Box::new(Self { delta })
+    }
+}
+
+impl<P: SingleObjectiveProblem> Component<P> for UpdateImprovedParticlePercentage {
+    fn initialize(&self, _problem: &P, state: &mut State<P>) {
+        state.insert(ImprovedParticlePercentage(0.));
+        state.insert(PreviousObjectiveValues(Vec::new()));
+    }
+
+    fn execute(&self, _problem: &P, state: &mut State<P>) {
+        let mut mut_state = state.get_states_mut();
+        let ParticleSwarm { bests, .. } = mut_state.get_mut::<ParticleSwarm<P>>();
+
+        let current = bests.iter().map(|i| *i.objective()).collect_vec();
+        let previous = mut_state.get_value_mut::<PreviousObjectiveValues>();
+
+        let n = bests.len() as f64;
+        let percentage = current
+            .iter()
+            .zip(previous.iter_mut())
+            .map(|(current, previous)| {
+                (previous.value() - current.value() > self.delta) as u8 as f64
+            })
+            .sum::<f64>()
+            / n;
+
+        mut_state.set_value::<ImprovedParticlePercentage>(percentage);
+        *previous = current;
+    }
+}
+
+impl<P: Problem> ParticleSwarm<P>
 where
     P: SingleObjectiveProblem<Encoding = Vec<f64>> + LimitedVectorProblem<T = f64>,
 {
     /// State initialization for PSO.
     ///
-    /// Initializes velocities, best found solutions of particles and global best in [PsoState].
+    /// Initializes velocities, best found solutions of particles and global best in [ParticleSwarm].
     pub fn initializer(v_max: f64) -> Box<dyn Component<P>> {
         #[derive(Debug, serde::Serialize, Clone)]
-        pub struct PsoStateInitialization {
+        pub struct ParticleSwarmInitalization {
             v_max: f64,
         }
 
-        impl<P> Component<P> for PsoStateInitialization
+        impl<P> Component<P> for ParticleSwarmInitalization
         where
             P: SingleObjectiveProblem<Encoding = Vec<f64>> + LimitedVectorProblem<T = f64>,
         {
             fn initialize(&self, _problem: &P, state: &mut State<P>) {
                 // Initialize with empty state to satisfy `state.require()` statements
-                state.insert(PsoState {
+                state.insert(ParticleSwarm {
                     velocities: vec![],
                     bests: vec![],
                     global_best: Individual::<P>::new_unevaluated(Vec::new()),
@@ -60,15 +111,11 @@ where
 
                 let bests = population.to_vec();
 
-                let global_best = bests
-                    .iter()
-                    .min_by_key(|i| Individual::objective(i))
-                    .cloned()
-                    .unwrap();
+                let global_best = bests.iter().min_by_key(|i| i.objective()).cloned().unwrap();
 
                 state.populations_mut().push(population);
 
-                state.insert(PsoState {
+                state.insert(ParticleSwarm {
                     velocities,
                     bests,
                     global_best,
@@ -76,32 +123,32 @@ where
             }
         }
 
-        Box::new(PsoStateInitialization { v_max })
+        Box::new(ParticleSwarmInitalization { v_max })
     }
 
     /// State update for PSO.
     ///
-    /// Updates best found solutions of particles and global best in [PsoState].
+    /// Updates best found solutions of particles and global best in [ParticleSwarm].
     pub fn updater() -> Box<dyn Component<P>> {
         #[derive(Debug, serde::Serialize, Clone)]
-        pub struct PsoStateUpdate;
+        pub struct ParticleSwarmUpdate;
 
-        impl<P> Component<P> for PsoStateUpdate
+        impl<P> Component<P> for ParticleSwarmUpdate
         where
             P: Problem<Encoding = Vec<f64>> + LimitedVectorProblem<T = f64>,
         {
             fn initialize(&self, _problem: &P, state: &mut State<P>) {
-                state.require::<Self, PsoState<P>>();
+                state.require::<Self, ParticleSwarm<P>>();
             }
 
             fn execute(&self, _problem: &P, state: &mut State<P>) {
                 let population = state.populations_mut().pop();
 
-                let PsoState {
+                let ParticleSwarm {
                     bests, global_best, ..
-                } = &mut state.get_mut::<PsoState<P>>();
+                } = state.get_mut::<ParticleSwarm<P>>();
 
-                for (individual, best) in population.iter().zip(bests.iter_mut()) {
+                for (individual, best) in multizip((&population, bests)) {
                     if best.objective() > individual.objective() {
                         *best = individual.clone();
 
@@ -115,6 +162,6 @@ where
             }
         }
 
-        Box::new(PsoStateUpdate)
+        Box::new(ParticleSwarmUpdate)
     }
 }

--- a/src/state/pso.rs
+++ b/src/state/pso.rs
@@ -80,11 +80,11 @@ where
     /// Initializes velocities, best found solutions of particles and global best in [ParticleSwarm].
     pub fn initializer(v_max: f64) -> Box<dyn Component<P>> {
         #[derive(Debug, serde::Serialize, Clone)]
-        pub struct ParticleSwarmInitalization {
+        pub struct ParticleSwarmInitialization {
             v_max: f64,
         }
 
-        impl<P> Component<P> for ParticleSwarmInitalization
+        impl<P> Component<P> for ParticleSwarmInitialization
         where
             P: SingleObjectiveProblem<Encoding = Vec<f64>> + LimitedVectorProblem<T = f64>,
         {
@@ -123,7 +123,7 @@ where
             }
         }
 
-        Box::new(ParticleSwarmInitalization { v_max })
+        Box::new(ParticleSwarmInitialization { v_max })
     }
 
     /// State update for PSO.

--- a/src/tracking/mod.rs
+++ b/src/tracking/mod.rs
@@ -8,7 +8,7 @@
 //! the optimization process.
 //!
 //! A Logger consists of [LogSet]s which in turn consist of
-//! [Trigger](trigger::Trigger) and [LogFn](functions::LogFn).
+//! [Trigger](trigger::Trigger) and [LogFn](extractor::LogFn).
 //! See their respective documentation pages for more information
 //! on how to use them.
 //!
@@ -23,7 +23,7 @@
 pub mod files;
 
 /// Utils to create log functions.
-pub mod functions;
+pub mod extractor;
 
 /// Collection of log triggers.
 pub mod trigger;

--- a/src/tracking/set.rs
+++ b/src/tracking/set.rs
@@ -1,6 +1,7 @@
 use better_any::Tid;
 use serde::Serialize;
 
+use crate::state::common::Iterations;
 use crate::{
     problems::Problem,
     state::{common, CustomState, State},
@@ -72,7 +73,10 @@ impl<'a, P: Problem + 'static> LogSet<'a, P> {
     /// Every 10 [Iteration][common::Iterations], [common::Evaluations] and [common::Progress] are logged.
     pub fn with_common_extractors(self, trigger: Box<dyn Trigger<'a, P> + 'a>) -> Self {
         self.with(trigger.clone(), functions::auto::<common::Evaluations, _>)
-            .with(trigger.clone(), functions::auto::<common::Progress, _>)
+            .with(
+                trigger.clone(),
+                functions::auto::<common::Progress<Iterations>, _>,
+            )
     }
 
     pub(crate) fn execute(&self, problem: &P, state: &mut State<'a, P>, step: &mut Step) {


### PR DESCRIPTION
I'm making this a draft for now as I'm not sure how we should integrate those hybrids. Just leave them as examples?

- Implements Simulated Annealing
- Adds inertia weight adaptation strategies for PSO
- Turns `Extractor` into a real trait
- Renames some things I think make more sense this way (e.g. `PsoState` to `ParticleSwarm`)
- Implements three PSO hybrids