### PR TITLE
Remove better_any patch.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,9 +33,6 @@ itertools = "0.10.5"
 better_any = { version = "0.2.0", features = ["derive"] }
 scoped_threadpool = "0.1.9"
 
-[patch.crates-io]
-better_typeid_derive = { git = "https://github.com/luleyleo/better_any", branch = "no-use-tidable", package = "better_typeid_derive" }
-
 [dev-dependencies]
 proptest = "1.0.0"
 

--- a/src/conditions/termination.rs
+++ b/src/conditions/termination.rs
@@ -9,7 +9,7 @@ use crate::{
         CustomState, State,
     },
 };
-use better_any::Tid;
+use better_any::{Tid, TidAble};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Clone)]

--- a/src/state/archive.rs
+++ b/src/state/archive.rs
@@ -1,6 +1,6 @@
 //! Archiving methods
 
-use better_any::Tid;
+use better_any::{Tid, TidAble};
 use serde::{Deserialize, Serialize};
 
 use crate::{

--- a/src/state/common.rs
+++ b/src/state/common.rs
@@ -1,6 +1,6 @@
 //! Common state used in most heuristics.
 
-use better_any::Tid;
+use better_any::{Tid, TidAble};
 use derive_more::{Deref, DerefMut};
 use serde::Serialize;
 

--- a/src/state/cro.rs
+++ b/src/state/cro.rs
@@ -1,4 +1,4 @@
-use better_any::Tid;
+use better_any::{Tid, TidAble};
 use rand::Rng;
 
 use crate::{

--- a/src/state/diversity.rs
+++ b/src/state/diversity.rs
@@ -2,7 +2,7 @@
 
 use std::marker::PhantomData;
 
-use better_any::Tid;
+use better_any::{Tid, TidAble};
 use serde::Serialize;
 
 use crate::{

--- a/src/state/pheromones.rs
+++ b/src/state/pheromones.rs
@@ -1,4 +1,4 @@
-use better_any::Tid;
+use better_any::{Tid, TidAble};
 use serde::Serialize;
 
 use crate::state::CustomState;

--- a/src/state/pso.rs
+++ b/src/state/pso.rs
@@ -1,4 +1,4 @@
-use better_any::Tid;
+use better_any::{Tid, TidAble};
 use rand::Rng;
 
 use crate::{

--- a/src/state/random.rs
+++ b/src/state/random.rs
@@ -2,7 +2,7 @@
 
 use std::any::type_name;
 
-use better_any::Tid;
+use better_any::{Tid, TidAble};
 use rand::{RngCore, SeedableRng};
 use serde::Serialize;
 

--- a/src/tracking/log.rs
+++ b/src/tracking/log.rs
@@ -1,6 +1,6 @@
 use std::any::type_name;
 
-use better_any::Tid;
+use better_any::{Tid, TidAble};
 use erased_serde::Serialize as DynSerialize;
 use serde::Serialize;
 

--- a/src/tracking/set.rs
+++ b/src/tracking/set.rs
@@ -1,4 +1,4 @@
-use better_any::Tid;
+use better_any::{Tid, TidAble};
 use serde::Serialize;
 
 use crate::{


### PR DESCRIPTION
The original author of the crate does not respond to my PR and I don't want to re-publish it right now. Maybe we can get rid of this dependency once we rework and simplify State.

Once this is merged, MAHF will no longer depend on any Git dependencies and could theoretically be published.