### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,5 +105,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          # --all-targets includes --benches, which we don't want.
           args: --workspace --all-features --doc --verbose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,31 +1,101 @@
 on:
   push:
     branches:
-    - master
+      - master
   pull_request:
     branches:
-    - master
+      - master
 
 env:
-  RUST_VERSION: 1.66.1
+  RUST_VERSION: 1.70.0
   CARGO_TERM_COLOR: always
 
 jobs:
-  ci:
+  check:
+    name: Check
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Install Rust
-      uses: actions-rs/toolchain@v1
-      with:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
           toolchain: ${{ env.RUST_VERSION }}
           override: true
-          components: rustfmt, clippy
-    - name: Format
-      run: cargo fmt --all -- --check --verbose
-    - name: Clippy
-      run: cargo clippy --workspace --all-targets --all-features -- -D warnings
-    - name: Build
-      run: cargo build --verbose
-    - name: Tests
-      run: cargo test --workspace --all-targets --all-features --verbose
+          components: clippy
+
+      - name: Run cargo check
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+
+      - name: Run cargo clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --workspace --all-targets --all-features -- -D warnings
+
+  test:
+    name: Test Suite
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ env.RUST_VERSION }}
+          override: true
+
+      - name: Run cargo test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --workspace --all-features --all-targets --verbose
+
+  rustfmt:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install nightly toolchain with rustfmt available
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+          components: rustfmt
+
+      - name: Run cargo fmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check --verbose
+
+  doc:
+    name: Doc
+    runs-on: ubuntu-latest
+    env:
+      RUSTDOCFLAGS: -D warnings
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ env.RUST_VERSION }}
+          override: true
+
+      - name: Run cargo doc
+        uses: actions-rs/cargo@v1
+        with:
+          command: doc
+          args: --no-deps --verbose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,8 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --workspace --all-features --all-targets --verbose
+          # --all-targets includes --benches, which we don't want.
+          args: --workspace --all-features --lib --bins --tests --examples --verbose
 
   rustfmt:
     name: Format
@@ -99,3 +100,10 @@ jobs:
         with:
           command: doc
           args: --no-deps --verbose
+
+      - name: Run cargo test --doc
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          # --all-targets includes --benches, which we don't want.
+          args: --workspace --all-features --doc --verbose

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+imports_granularity = "Crate"
+group_imports = "StdExternalCrate"

--- a/src/components/boundary.rs
+++ b/src/components/boundary.rs
@@ -10,10 +10,10 @@ use rand::distributions::Distribution;
 use rand_distr::Normal;
 use serde::{Deserialize, Serialize};
 
-use crate::population::AsSolutionsMut;
 use crate::{
     component::{AnyComponent, ExecResult},
     components::Component,
+    population::AsSolutionsMut,
     problems::LimitedVectorProblem,
     state::{random::Random, State},
     Problem,

--- a/src/components/selection/functional.rs
+++ b/src/components/selection/functional.rs
@@ -5,8 +5,9 @@
 use itertools::Itertools;
 use rand::distributions::{Distribution, WeightedError, WeightedIndex};
 
-use crate::utils::all_eq;
-use crate::{problems::SingleObjectiveProblem, state::random::Random, Individual, Problem};
+use crate::{
+    problems::SingleObjectiveProblem, state::random::Random, utils::all_eq, Individual, Problem,
+};
 
 /// Returns the `(max, min)` objective values of the population if it is non-empty, or `None` otherwise.
 pub fn objective_bounds<P: SingleObjectiveProblem>(

--- a/src/conditions/common.rs
+++ b/src/conditions/common.rs
@@ -12,13 +12,12 @@ use rand::Rng;
 use serde::{Deserialize, Serialize};
 use trait_set::trait_set;
 
-use crate::state::common::{Evaluations, Iterations};
 use crate::{
     component::ExecResult,
     conditions::Condition,
     lens::{AnyLens, Lens, LensRef},
     problems::KnownOptimumProblem,
-    state::common::Progress,
+    state::common::{Evaluations, Iterations, Progress},
     CustomState, Problem, State, ValueOf,
 };
 

--- a/src/lens/mod.rs
+++ b/src/lens/mod.rs
@@ -21,8 +21,10 @@
 //!
 //! [`lenses`]: https://rust-unofficial.github.io/patterns/functional/lenses.html
 
-use std::cell::{Ref, RefMut};
-use std::ops::Deref;
+use std::{
+    cell::{Ref, RefMut},
+    ops::Deref,
+};
 
 use serde::Serialize;
 use trait_set::trait_set;


### PR DESCRIPTION
- Separate jobs for `{clippy, check}`, `test`, `rustfmt`, and `doc` to instantly view what failed
- Add `rustfmt.toml` (some options require `rustfmt +nightly`)
- Checks for warnings when building docs